### PR TITLE
PHP notice on line 228 of bp-activity-subscription-functions.php

### DIFF
--- a/bp-activity-subscription-functions.php
+++ b/bp-activity-subscription-functions.php
@@ -225,7 +225,7 @@ function ass_group_notification_activity( $content ) {
 		$component = 'groups';
 
 	// at this point we only want group activity, perhaps later we can make a function and interface for personal activity...
-	if ( $component != 'groups' && ! $is_activity_comment )
+	if ( $component != 'groups' )
 		return;
 
 	if ( !ass_registered_long_enough( $bp->loggedin_user->id ) )


### PR DESCRIPTION
On line 228 of bp-activity-subscription-functions.php, the variable $is_activity_comment is used but it was not previously declared.
