### PR TITLE
timezone bug fix and minor action added

### DIFF
--- a/bp-activity-subscription-digest.php
+++ b/bp-activity-subscription-digest.php
@@ -316,6 +316,7 @@ function ass_digest_format_item( $item, $type ) {
 //	$timestamp = strtotime( $item->date_recorded );
 
 	/* Because BuddyPress core set gmt = true, timezone must be added */
+	date_default_timezone_set(get_option('timezone_string'));//ensure php's timezone is in sync with wordpress'
 	$timestamp = strtotime( $item->date_recorded ) +date('Z');
 
 	$time_posted = date( get_option( 'time_format' ), $timestamp );

--- a/bp-activity-subscription-functions.php
+++ b/bp-activity-subscription-functions.php
@@ -1399,6 +1399,9 @@ If you feel this service is being misused please speak to the website administra
 
 			$user_ids = BP_Groups_Member::get_group_member_ids( $group_id );
 
+			//allow others to perform an action when this type of email is sent, like adding to the activity feed
+			do_action('ass_admin_notice',$group_id,$subject,$_POST[ 'ass_admin_notice' ]); 
+			
 			// cycle through all group members
 			foreach ( (array)$user_ids as $user_id ) {
 				$user = bp_core_get_core_userdata( $user_id ); // Get the details for the user


### PR DESCRIPTION
I added an action to get called to allow me (and other developers) to do any action we want when an admin sends a forced-email through the plugin. IE, our client wanted forced-emails to also appear in the group activity feed. So I added this action, which I can then listen for, and when it's actioned create a new activity item.
Also, a bug fix to the time reported on group activity digests. It was always reporting events as being in GMT, not the wordpress-defined timezone we wanted.
I hope these small additions are good ones!