### PR TITLE
Tweaks for bbPress 2

### DIFF
--- a/bp-activity-subscription-functions.php
+++ b/bp-activity-subscription-functions.php
@@ -900,6 +900,21 @@ function ass_get_default_subscription( $group = false ) {
 //	!TOPIC SUBSCRIPTION
 //
 
+/**
+ * Disables bbPress 2's subscription block.
+ *
+ * GES already covers group email subscription, so disable bbPress 2's
+ * functionality when on a BuddyPress group page.
+ *
+ * @since 3.2.2
+ */
+function ass_disable_bbp_subscriptions( $retval ) {
+	if ( bp_is_group() )
+		return false;
+
+	return $retval;
+}
+add_filter( 'bbp_is_subscriptions_active', 'ass_disable_bbp_subscriptions' );
 
 function ass_get_topic_subscription_status( $user_id, $topic_id ) {
 	global $bp;


### PR DESCRIPTION
Hi Boone,

I've introduced three new functions:
- `ass_group_activity_edits()` - Catches edited group activity items.  If an activity item is being edited, stop GES from sending / recording.  This addresses issues with edited bbPress group forum posts from being sent again and any edited group activity items in the future.
- `ass_disable_bbp_subscriptions()` - Disables bbPress 2's subscription checkbox when on a BuddyPress group topic page.  
- `ass_default_block_group_activity_types()` - Not really bbPress-specific.  Just extrapolated some code from `ass_group_notification_activity()` so it's more dev-friendly instead of hardcoding the activity types.  This might address #12.

Let me know what you think!
