### PR TITLE
Digest enhancements

### DIFF
--- a/bp-activity-subscription-digest.php
+++ b/bp-activity-subscription-digest.php
@@ -84,6 +84,11 @@ function ass_digest_fire( $type ) {
 	// get all user subscription data
 	$user_subscriptions = $wpdb->get_results( "SELECT user_id, meta_value FROM {$wpdb->usermeta} WHERE meta_key = 'ass_digest_items' AND meta_value != ''" );
 
+	// no subscription data? stop now!
+	if ( empty( $user_subscriptions ) ) {
+		return;
+	}
+
 	// get all activity IDs for everyone subscribed to a digest
 	$all_activity_items = array();
 


### PR DESCRIPTION
Hi Boone,

I've done a number of things for digests so it will perform a bit better.
- commit 3f5ed61 - Switch from `in_array()` and use `isset()`. (See #39)
- commit d0200e1 - Do not use `bp_activity_get_specific()`
- commit 4dfa4fe - Use an alternative function for `bp_core_get_user_domain()` to prevent using it in our digest foreach loop.
- commit 4f95d60 - Remove reply count from weekly digests as that uses `'bbpress_init'` for each forum topic.
- commit 61dc047 - Check if user's subscribed activity IDs still exist. (See #25)

Let me know what you think.

Also, @epawel, since you have a rather large BP site that relies on GES, if you can test these changes and let me know how it performs that would be great as well.
