### PR TITLE
Updates to enable support on custom components

### DIFF
--- a/bp-activity-subscription-js.js
+++ b/bp-activity-subscription-js.js
@@ -41,7 +41,7 @@ jQuery(document).ready( function() {
 
 
 	// group subscription options
-	j( '#groups-dir-list,#item-header' ).on("click", '.group-sub', function() {
+	j( '.item-list,#item-header' ).on("click", '.group-sub', function() {
 		it = j(this);
 		var theid = j(this).attr('id');
 		var stheid = theid.split('-');

--- a/bp-activity-subscription-js.js
+++ b/bp-activity-subscription-js.js
@@ -70,13 +70,13 @@ jQuery(document).ready( function() {
 
 	});
 
-	j( '#groups-dir-list,#item-header' ).on("click", '.group-subscription-options-link', function() {
+	j( '.item-list,#item-header' ).on("click", '.group-subscription-options-link', function() {
 		stheid = j(this).attr('id').split('-');
 		group_id = stheid[1];
 		j( '#gsubopt-'+group_id ).slideToggle('fast');
 	});
 
-	j( '#groups-dir-list,#item-header' ).on("click", '.group-subscription-close', function() {
+	j( '.item-list,#item-header' ).on("click", '.group-subscription-close', function() {
 		stheid = j(this).attr('id').split('-');
 		group_id = stheid[1];
 		j( '#gsubopt-'+group_id ).slideToggle('fast');

--- a/bp-activity-subscription-main.php
+++ b/bp-activity-subscription-main.php
@@ -42,35 +42,39 @@ class Group_Activity_Subscription extends BP_Group_Extension {
 	}
 
 	public function add_settings_stylesheet() {
-		$revision_date = '20130729';
+		if ( apply_filters( 'ass_load_assets', bp_is_groups_component() ) ) {
+			$revision_date = '20130729';
 
-		wp_register_style(
-			'activity-subscription-style',
-			plugins_url( 'css/bp-activity-subscription-css.css', __FILE__ ),
-			array(),
-			$revision_date
-		);
+			wp_register_style(
+				'activity-subscription-style',
+				plugins_url( 'css/bp-activity-subscription-css.css', __FILE__ ),
+				array(),
+				$revision_date
+			);
 
-		wp_enqueue_style( 'activity-subscription-style' );
+			wp_enqueue_style( 'activity-subscription-style' );
+		}
 	}
 
 	public function ass_add_javascript() {
-		$revision_date = '20130729';
+		if ( apply_filters( 'ass_load_assets', bp_is_groups_component() ) ) {
+			$revision_date = '20130729';
 
-		wp_register_script(
-			'bp-activity-subscription-js',
-			plugins_url( 'bp-activity-subscription-js.js', __FILE__ ),
-			array( 'jquery' ),
-			$revision_date
-		);
+			wp_register_script(
+				'bp-activity-subscription-js',
+				plugins_url( 'bp-activity-subscription-js.js', __FILE__ ),
+				array( 'jquery' ),
+				$revision_date
+			);
 
-		wp_enqueue_script( 'bp-activity-subscription-js' );
+			wp_enqueue_script( 'bp-activity-subscription-js' );
 
-		wp_localize_script( 'bp-activity-subscription-js', 'bp_ass', array(
-			'mute'   => __( 'Mute', 'bp-ass' ),
-			'follow' => __( 'Follow', 'bp-ass' ),
-			'error'  => __( 'Error', 'bp-ass' )
-		) );
+			wp_localize_script( 'bp-activity-subscription-js', 'bp_ass', array(
+				'mute'   => __( 'Mute', 'bp-ass' ),
+				'follow' => __( 'Follow', 'bp-ass' ),
+				'error'  => __( 'Error', 'bp-ass' )
+			) );
+		}
 	}
 
 	// Display the notification settings form

--- a/bp-activity-subscription-main.php
+++ b/bp-activity-subscription-main.php
@@ -42,39 +42,35 @@ class Group_Activity_Subscription extends BP_Group_Extension {
 	}
 
 	public function add_settings_stylesheet() {
-		if ( bp_is_groups_component() ) {
-			$revision_date = '20130729';
+		$revision_date = '20130729';
 
-			wp_register_style(
-				'activity-subscription-style',
-				plugins_url( 'css/bp-activity-subscription-css.css', __FILE__ ),
-				array(),
-				$revision_date
-			);
+		wp_register_style(
+			'activity-subscription-style',
+			plugins_url( 'css/bp-activity-subscription-css.css', __FILE__ ),
+			array(),
+			$revision_date
+		);
 
-			wp_enqueue_style( 'activity-subscription-style' );
-		}
+		wp_enqueue_style( 'activity-subscription-style' );
 	}
 
 	public function ass_add_javascript() {
-		if ( bp_is_groups_component() ) {
-			$revision_date = '20130729';
+		$revision_date = '20130729';
 
-			wp_register_script(
-				'bp-activity-subscription-js',
-				plugins_url( 'bp-activity-subscription-js.js', __FILE__ ),
-				array( 'jquery' ),
-				$revision_date
-			);
+		wp_register_script(
+			'bp-activity-subscription-js',
+			plugins_url( 'bp-activity-subscription-js.js', __FILE__ ),
+			array( 'jquery' ),
+			$revision_date
+		);
 
-			wp_enqueue_script( 'bp-activity-subscription-js' );
+		wp_enqueue_script( 'bp-activity-subscription-js' );
 
-			wp_localize_script( 'bp-activity-subscription-js', 'bp_ass', array(
-				'mute'   => __( 'Mute', 'bp-ass' ),
-				'follow' => __( 'Follow', 'bp-ass' ),
-				'error'  => __( 'Error', 'bp-ass' )
-			) );
-		}
+		wp_localize_script( 'bp-activity-subscription-js', 'bp_ass', array(
+			'mute'   => __( 'Mute', 'bp-ass' ),
+			'follow' => __( 'Follow', 'bp-ass' ),
+			'error'  => __( 'Error', 'bp-ass' )
+		) );
 	}
 
 	// Display the notification settings form


### PR DESCRIPTION
In my instance I have enabled the functionality within a custom courses component for Buddypress. To do so I had to modify the code to provide on all components.

A potential better solution is providing a setting for selecting from existing components rather than just enabling for everything.