### PR TITLE
Hide popovers when group directory tabs are selected

### DIFF
--- a/bp-activity-subscription-js.js
+++ b/bp-activity-subscription-js.js
@@ -97,4 +97,9 @@ jQuery(document).ready( function() {
 		}
 	});
 
+	// hide popover when tabs are selected and AJAX returns are inserted into the DOM
+	j('#groups-dir-list').on('DOMNodeInserted', function() {
+		j('.group-subscription-options').hide();
+	});
+
 });


### PR DESCRIPTION
Fixes the unwanted appearance of BPGES popovers when a group directory tab are selected and new content is pulled in via AJAX.