### PR TITLE
Use `ass_send_email()` for group notices.

### DIFF
--- a/screen-admin.php
+++ b/screen-admin.php
@@ -173,6 +173,20 @@ To view this group log in and follow the link below:
 If you feel this service is being misused please speak to the website administrator.', 'bp-ass' );
 
 			$user_ids = BP_Groups_Member::get_group_member_ids( $group_id );
+			$admin_info = bp_core_get_core_userdata( bp_loggedin_user_id() );
+
+			$email_tokens = array(
+				'ges.subject'  => stripslashes( strip_tags( $subject ) ),
+				'usermessage'  => $message,
+				'group.link'   => sprintf( '<a href="%1$s">%2$s</a>', esc_url( $group_link ), $group_name ),
+				'group.name'   => $group_name,
+				'group.url'    => esc_url( $group_link ),
+				'group.id'     => $group_id,
+				'group.admin'  => $admin_info->display_name,
+				'ges.settings-link' => ass_get_login_redirect_url( trailingslashit( $group_link . 'notifications' ), 'welcome' ),
+				'ges.unsubscribe'   => ass_get_group_unsubscribe_link_for_user( $user->ID, $group_id ),
+				'ges.unsubscribe-global' => ass_get_group_unsubscribe_link_for_user( $user->ID, $group_id, true ),
+			);
 
 			// allow others to perform an action when this type of email is sent, like adding to the activity feed
 			do_action( 'ass_admin_notice', $group_id, $subject, $notice );
@@ -181,10 +195,21 @@ If you feel this service is being misused please speak to the website administra
 			foreach ( (array)$user_ids as $user_id ) {
 				$user = bp_core_get_core_userdata( $user_id ); // Get the details for the user
 
-				if ( $user->user_email )
-					wp_mail( $user->user_email, $subject, $message );  // Send the email
+				if ( empty( $user->user_email ) ) {
+					continue;
+				}
 
-				//echo '<br>Email: ' . $user->user_email;
+				$email_tokens['recipient.id'] = $user->ID;
+
+				ass_send_email( 'bp-ges-notice', $user->user_email, array(
+					'tokens'  => $email_tokens,
+					'subject' => $subject,
+					'content' => $message,
+					'from' => array(
+						'name'   => $admin_info->display_name,
+						'email'  => $admin_info->user_email,
+					)
+				) );
 			}
 
 			bp_core_add_message( __( 'The email notice was sent successfully.', 'bp-ass' ) );

--- a/screen-admin.php
+++ b/screen-admin.php
@@ -177,7 +177,7 @@ If you feel this service is being misused please speak to the website administra
 
 			$email_tokens = array(
 				'ges.subject'  => stripslashes( strip_tags( $subject ) ),
-				'usermessage'  => $message,
+				'usermessage'  => $notice,
 				'group.link'   => sprintf( '<a href="%1$s">%2$s</a>', esc_url( $group_link ), $group_name ),
 				'group.name'   => $group_name,
 				'group.url'    => esc_url( $group_link ),


### PR DESCRIPTION
This lets us leverage the `bp-ges-notice` BP mail type, which has been
around for a while but which has never been used.

@r-a-y I assume that this was an oversight when the BP mail stuff was added. Could you have a look to make sure this looks OK to you?