### PR TITLE
Feature: add filter to customize which subscription options will be displayed

### DIFF
--- a/bp-activity-subscription-functions.php
+++ b/bp-activity-subscription-functions.php
@@ -1515,15 +1515,23 @@ function ass_manage_members_email_status(  $user_id = '', $group = '' ) {
 	$sub_type = ass_get_group_subscription_status( $user_id, $group->id );
 	echo '<span class="ass_manage_members_links"> '.__('Email status:','bp-ass').' ' . ass_subscribe_translate( $sub_type ) . '.';
 	echo ' &nbsp; '.__('Change to:','bp-ass').' ';
-	echo '<a href="' . wp_nonce_url( $group_url.'/no/'.$user_id, 'ass_member_email_status' ) . '">'.__('No Email','bp-ass').'</a> | ';
-	echo '<a href="' . wp_nonce_url( $group_url.'/sum/'.$user_id, 'ass_member_email_status' ) . '">'.__('Weekly','bp-ass').'</a> | ';
-	echo '<a href="' . wp_nonce_url( $group_url.'/dig/'.$user_id, 'ass_member_email_status' ) . '">'.__('Daily','bp-ass').'</a> | ';
 
-	if ( ass_get_forum_type() ) {
+	if ( display_subscription_option('no') ) {
+		echo '<a href="' . wp_nonce_url( $group_url.'/no/'.$user_id, 'ass_member_email_status' ) . '">'.__('No Email','bp-ass').'</a> | ';
+	}
+	if ( display_subscription_option('sum') ) {
+		echo '<a href="' . wp_nonce_url( $group_url.'/sum/'.$user_id, 'ass_member_email_status' ) . '">'.__('Weekly','bp-ass').'</a> | ';
+	}
+	if ( display_subscription_option('dig') ) {
+		echo '<a href="' . wp_nonce_url( $group_url.'/dig/'.$user_id, 'ass_member_email_status' ) . '">'.__('Daily','bp-ass').'</a> | ';
+	}
+	if ( ass_get_forum_type() && display_subscription_option('sub') ) {
 		echo '<a href="' . wp_nonce_url( $group_url.'/sub/'.$user_id, 'ass_member_email_status' ) . '">'.__('New Topics','bp-ass').'</a> | ';
 	}
-
-	echo '<a href="' . wp_nonce_url( $group_url.'/supersub/'.$user_id, 'ass_member_email_status' ) . '">'.__('All Email','bp-ass').'</a>';
+	if ( display_subscription_option('supersub') ) {
+		echo '<a href="' . wp_nonce_url( $group_url.'/supersub/'.$user_id, 'ass_member_email_status' ) . '">'.__('All Email','bp-ass').'</a>';
+	}
+	
 	echo '</span>';
 }
 add_action( 'bp_group_manage_members_admin_item', 'ass_manage_members_email_status' );
@@ -1894,3 +1902,14 @@ function bpges_register_template_stack() {
 	}, 20 );
 }
 add_action( 'bp_actions', 'bpges_register_template_stack' );
+
+/**
+ * Check that the given subscription option should be displayed
+ * Possible values for $option: no, sum, dig, sub, supersub
+ *
+ */
+function display_subscription_option($option) {
+	$subscriptionOptions = array('no', 'sum', 'dig', 'sub', 'supersub');
+	$subscriptionOptions = apply_filters('bp_group_email_subscription_subscription_options', $subscriptionOptions);
+	return in_array($option, $subscriptionOptions);
+}

--- a/screen-admin.php
+++ b/screen-admin.php
@@ -11,20 +11,30 @@ function ass_default_subscription_settings_form() {
 	<h4><?php _e('Email Subscription Defaults', 'bp-ass'); ?></h4>
 	<p><?php _e('When new users join this group, their default email notification settings will be:', 'bp-ass'); ?></p>
 	<div class="radio">
-		<label><input type="radio" name="ass-default-subscription" value="no" <?php ass_default_subscription_settings( 'no' ) ?> />
-			<?php _e( 'No Email (users will read this group on the web - good for any group)', 'bp-ass' ) ?></label>
-		<label><input type="radio" name="ass-default-subscription" value="sum" <?php ass_default_subscription_settings( 'sum' ) ?> />
-			<?php _e( 'Weekly Summary Email (the week\'s topics - good for large groups)', 'bp-ass' ) ?></label>
-		<label><input type="radio" name="ass-default-subscription" value="dig" <?php ass_default_subscription_settings( 'dig' ) ?> />
-			<?php _e( 'Daily Digest Email (all daily activity bundles in one email - good for medium-size groups)', 'bp-ass' ) ?></label>
-
-		<?php if ( ass_get_forum_type() ) : ?>
-			<label><input type="radio" name="ass-default-subscription" value="sub" <?php ass_default_subscription_settings( 'sub' ) ?> />
-			<?php _e( 'New Topics Email (new topics are sent as they arrive, but not replies - good for small groups)', 'bp-ass' ) ?></label>
+		<?php if ( display_subscription_option('no') ) : ?>
+			<label><input type="radio" name="ass-default-subscription" value="no" <?php ass_default_subscription_settings( 'no' ) ?> />
+				<?php _e( 'No Email (users will read this group on the web - good for any group)', 'bp-ass' ) ?></label>
 		<?php endif; ?>
 
-		<label><input type="radio" name="ass-default-subscription" value="supersub" <?php ass_default_subscription_settings( 'supersub' ) ?> />
-			<?php _e( 'All Email (send emails about everything - recommended only for working groups)', 'bp-ass' ) ?></label>
+		<?php if ( display_subscription_option('sum') ) : ?>
+			<label><input type="radio" name="ass-default-subscription" value="sum" <?php ass_default_subscription_settings( 'sum' ) ?> />
+				<?php _e( 'Weekly Summary Email (the week\'s topics - good for large groups)', 'bp-ass' ) ?></label>
+		<?php endif; ?>
+
+		<?php if ( display_subscription_option('dig') ) : ?>
+			<label><input type="radio" name="ass-default-subscription" value="dig" <?php ass_default_subscription_settings( 'dig' ) ?> />
+				<?php _e( 'Daily Digest Email (all daily activity bundles in one email - good for medium-size groups)', 'bp-ass' ) ?></label>
+		<?php endif; ?>
+
+		<?php if ( ass_get_forum_type() && display_subscription_option('sub') ) : ?>
+			<label><input type="radio" name="ass-default-subscription" value="sub" <?php ass_default_subscription_settings( 'sub' ) ?> />
+				<?php _e( 'New Topics Email (new topics are sent as they arrive, but not replies - good for small groups)', 'bp-ass' ) ?></label>
+		<?php endif; ?>
+
+		<?php if ( display_subscription_option('supersub') ) : ?>
+			<label><input type="radio" name="ass-default-subscription" value="supersub" <?php ass_default_subscription_settings( 'supersub' ) ?> />
+				<?php _e( 'All Email (send emails about everything - recommended only for working groups)', 'bp-ass' ) ?></label>
+		<?php endif; ?>
 	</div>
 	<hr />
 	<?php

--- a/screen-notifications.php
+++ b/screen-notifications.php
@@ -27,32 +27,40 @@ function ass_group_subscribe_settings () {
 
 	<b><?php _e('How do you want to read this group?', 'bp-ass'); ?></b>
 
-	<div class="ass-email-type">
-	<label><input type="radio" name="ass_group_subscribe" value="no" <?php if ( $group_status == "no" || $group_status == "un" || !$group_status ) echo 'checked="checked"'; ?>><?php _e('No Email', 'bp-ass'); ?></label>
-	<div class="ass-email-explain"><?php _e('I will read this group on the web', 'bp-ass'); ?></div>
-	</div>
+	<?php if ( display_subscription_option('no') ) : ?>
+		<div class="ass-email-type">
+		<label><input type="radio" name="ass_group_subscribe" value="no" <?php if ( $group_status == "no" || $group_status == "un" || !$group_status ) echo 'checked="checked"'; ?>><?php _e('No Email', 'bp-ass'); ?></label>
+		<div class="ass-email-explain"><?php _e('I will read this group on the web', 'bp-ass'); ?></div>
+		</div>
+	<?php endif; ?>
 
-	<div class="ass-email-type">
-	<label><input type="radio" name="ass_group_subscribe" value="sum" <?php if ( $group_status == "sum" ) echo 'checked="checked"'; ?>><?php _e('Weekly Summary Email', 'bp-ass'); ?></label>
-	<div class="ass-email-explain"><?php _e('Get a summary of new topics each week', 'bp-ass'); ?></div>
-	</div>
+	<?php if ( display_subscription_option('sum') ) : ?>	
+		<div class="ass-email-type">
+		<label><input type="radio" name="ass_group_subscribe" value="sum" <?php if ( $group_status == "sum" ) echo 'checked="checked"'; ?>><?php _e('Weekly Summary Email', 'bp-ass'); ?></label>
+		<div class="ass-email-explain"><?php _e('Get a summary of new topics each week', 'bp-ass'); ?></div>
+		</div>
+	<?php endif; ?>
 
-	<div class="ass-email-type">
-	<label><input type="radio" name="ass_group_subscribe" value="dig" <?php if ( $group_status == "dig" ) echo 'checked="checked"'; ?>><?php _e('Daily Digest Email', 'bp-ass'); ?></label>
-	<div class="ass-email-explain"><?php _e('Get all the day\'s activity bundled into a single email', 'bp-ass'); ?></div>
-	</div>
+	<?php if ( display_subscription_option('dig') ) : ?>
+		<div class="ass-email-type">
+		<label><input type="radio" name="ass_group_subscribe" value="dig" <?php if ( $group_status == "dig" ) echo 'checked="checked"'; ?>><?php _e('Daily Digest Email', 'bp-ass'); ?></label>
+		<div class="ass-email-explain"><?php _e('Get all the day\'s activity bundled into a single email', 'bp-ass'); ?></div>
+		</div>
+	<?php endif; ?>
 
-	<?php if ( ass_get_forum_type() ) : ?>
+	<?php if ( ass_get_forum_type() && display_subscription_option('sub') ) : ?>
 		<div class="ass-email-type">
 		<label><input type="radio" name="ass_group_subscribe" value="sub" <?php if ( $group_status == "sub" ) echo 'checked="checked"'; ?>><?php _e('New Topics Email', 'bp-ass'); ?></label>
 		<div class="ass-email-explain"><?php _e('Send new topics as they arrive (but don\'t send replies)', 'bp-ass'); ?></div>
 		</div>
 	<?php endif; ?>
 
-	<div class="ass-email-type">
-	<label><input type="radio" name="ass_group_subscribe" value="supersub" <?php if ( $group_status == "supersub" ) echo 'checked="checked"'; ?>><?php _e('All Email', 'bp-ass'); ?></label>
-	<div class="ass-email-explain"><?php _e('Send all group activity as it arrives', 'bp-ass'); ?></div>
-	</div>
+	<?php if ( display_subscription_option('supersub') ) : ?>
+		<div class="ass-email-type">
+		<label><input type="radio" name="ass_group_subscribe" value="supersub" <?php if ( $group_status == "supersub" ) echo 'checked="checked"'; ?>><?php _e('All Email', 'bp-ass'); ?></label>
+		<div class="ass-email-explain"><?php _e('Send all group activity as it arrives', 'bp-ass'); ?></div>
+		</div>
+	<?php endif; ?>	
 
 	<input type="submit" value="<?php _e('Save Settings', 'bp-ass') ?>" id="ass-save" name="ass-save" class="button-primary">
 

--- a/screen.php
+++ b/screen.php
@@ -50,15 +50,26 @@ function ass_group_subscribe_button() {
 		<span class="ajax-loader" id="gsubajaxload-<?php echo $group->id; ?>"></span>
 	</div>
 	<div class="generic-button group-subscription-options" id="gsubopt-<?php echo $group->id; ?>" style="display:none;">
-		<a class="group-sub" id="no-<?php echo $group->id; ?>"><?php _e('No Email', 'bp-ass') ?></a> <?php _e('I will read this group on the web', 'bp-ass') ?><br>
-		<a class="group-sub" id="sum-<?php echo $group->id; ?>"><?php _e('Weekly Summary', 'bp-ass') ?></a> <?php _e('Get a summary of topics each', 'bp-ass') ?> <?php echo ass_weekly_digest_week(); ?><br>
-		<a class="group-sub" id="dig-<?php echo $group->id; ?>"><?php _e('Daily Digest', 'bp-ass') ?></a> <?php _e('Get the day\'s activity bundled into one email', 'bp-ass') ?><br>
+		<?php if ( display_subscription_option('no') ) : ?>
+			<a class="group-sub" id="no-<?php echo $group->id; ?>"><?php _e('No Email', 'bp-ass') ?></a> <?php _e('I will read this group on the web', 'bp-ass') ?><br>
+		<?php endif; ?>
 
-		<?php if ( ass_get_forum_type() ) : ?>
+		<?php if ( display_subscription_option('sum') ) : ?>
+			<a class="group-sub" id="sum-<?php echo $group->id; ?>"><?php _e('Weekly Summary', 'bp-ass') ?></a> <?php _e('Get a summary of topics each', 'bp-ass') ?> <?php echo ass_weekly_digest_week(); ?><br>
+		<?php endif; ?>
+
+		<?php if ( display_subscription_option('dig') ) : ?>
+			<a class="group-sub" id="dig-<?php echo $group->id; ?>"><?php _e('Daily Digest', 'bp-ass') ?></a> <?php _e('Get the day\'s activity bundled into one email', 'bp-ass') ?><br>
+		<?php endif; ?>
+
+		<?php if ( ass_get_forum_type() && display_subscription_option('sub') ) : ?>
 			<a class="group-sub" id="sub-<?php echo $group->id; ?>"><?php _e('New Topics', 'bp-ass') ?></a> <?php _e('Send new topics as they arrive (but no replies)', 'bp-ass') ?><br>
 		<?php endif; ?>
 
-		<a class="group-sub" id="supersub-<?php echo $group->id; ?>"><?php _e('All Email', 'bp-ass') ?></a> <?php _e('Send all group activity as it arrives', 'bp-ass') ?><br>
+		<?php if ( display_subscription_option('supersub') ) : ?>
+			<a class="group-sub" id="supersub-<?php echo $group->id; ?>"><?php _e('All Email', 'bp-ass') ?></a> <?php _e('Send all group activity as it arrives', 'bp-ass') ?><br>
+		<?php endif; ?>
+
 		<a class="group-subscription-close" id="gsubclose-<?php echo $group->id; ?>"><?php _e('close', 'bp-ass') ?></a>
 	</div>
 


### PR DESCRIPTION
Thanks for another great buddypress plugin!! This is a suggestion to make it possible to control which of the different subscription options will be displayed with a filter. I found this to be a request at the site I'm working on, as we only have very similar groups with very similar requirements, and wanted to keep the interface for the users as small and simple as possible, so we wanted to limit down the subscription options to only "None" or "All". I think this feature might probably benefit others as well.

I'm quite new to WP plugin development, so if this is not the correct approach or I made some mistakes here, I'd be happy to improve it :)