### PR TITLE
Fix fatal error when deleting activity items not connected to a group

### DIFF
--- a/bp-activity-subscription-functions.php
+++ b/bp-activity-subscription-functions.php
@@ -1242,6 +1242,9 @@ function bpges_delete_queued_items_for_activity_ids( $activity_ids ) {
 		) );
 
 		$queued_ids = array_keys( $query->get_results() );
+		if ( empty( $queued_ids ) ) {
+			return;
+		}
 		BPGES_Queued_Item::bulk_delete( $queued_ids );
 	}
 }


### PR DESCRIPTION
Hi Boone,

This PR fixes a fatal error when deleting an activity item not connected to any group subscription.

Steps to duplicate:
1. Post an update in the Activity directory.
2. Delete the newly-created activity item.
3. AJAX deletion hangs and fatal error is logged in `debug.log`