### PR TITLE
Prevent duplicate entries from being recorded into the 'wp_bpges_queued_items' DB table

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -370,7 +370,8 @@ function bpges_install_queued_items_table() {
 				KEY user_id (user_id),
 				KEY group_id (group_id),
 				KEY activity_id (activity_id),
-				KEY user_group_type_date (user_id,type,date_recorded)
+				KEY user_group_type_date (user_id,type,date_recorded),
+				UNIQUE KEY user_group_activity_type (user_id,group_id,activity_id,type)
 			) {$charset_collate};";
 
 	dbDelta( $sql );

--- a/admin.php
+++ b/admin.php
@@ -368,7 +368,7 @@ function bpges_install_queued_items_table() {
 				type varchar(75) NOT NULL,
 				date_recorded datetime NOT NULL default '0000-00-00 00:00:00',
 				KEY user_id (user_id),
-				KEY group_id (user_id),
+				KEY group_id (group_id),
 				KEY activity_id (activity_id),
 				KEY user_group_type_date (user_id,type,date_recorded)
 			) {$charset_collate};";

--- a/classes/class-bpges-queued-item.php
+++ b/classes/class-bpges-queued-item.php
@@ -60,7 +60,7 @@ class BPGES_Queued_Item extends BPGES_Database_Object {
 
 		$table_name = self::get_table_name();
 		$values_sql = implode( ', ', $values );
-		$sql = "INSERT INTO {$table_name} (user_id, group_id, activity_id, type, date_recorded) VALUES {$values_sql}";
+		$sql = "INSERT IGNORE INTO {$table_name} (user_id, group_id, activity_id, type, date_recorded) VALUES {$values_sql}";
 		return $wpdb->query( $sql );
 	}
 


### PR DESCRIPTION
Ran into a scenario where the same queued item can be recorded into the DB more than once.

This can occur if `ass_group_notification_activity()` is run twice, which can be caused when a plugin is modifying the activity item and resaving the activity entry.

In this PR, I opted to fix this by adding a unique index to the `wp_bpges_queued_items` DB table.  This prevents duplicates from being inserted.  I've also written a unit test outlining the bug.

After the PR is merged, we would also need to bump the updater.

Lastly, I fixed a typo for the `group_id` index using the wrong column name.  Up to you whether we should also add this to the updater routine, but since 3.9.x is still in development, we don't really have to do this.  We'll just have to fix this on our installs running 3.9.x.