### PR TITLE
Bail from updater if BuddyPress isn't available

### DIFF
--- a/updater.php
+++ b/updater.php
@@ -45,6 +45,11 @@ class GES_Updater {
 	 * Update routine.
 	 */
 	protected function init() {
+		// Bail if BuddyPress isn't available.
+		if ( ! function_exists( 'bp_get_option' ) ) {
+			return;
+		}
+
 		$installed_date = (int) self::get_installed_revision_date();
 
 		// Sept 28, 2016 - Install email post types.


### PR DESCRIPTION
If BuddyPress isn't active when GES is activated, GES will throw a fatal error because the GES updater uses the BuddyPress options API (`bp_get_option()`, `bp_update_option()`, `bp_add_option()`).

Let's bail from the updater if BP isn't active.  The updater will kick in when on various admin pages anyway.