### PR TITLE
Allow BP email_type to be filtered.

### DIFF
--- a/bp-activity-subscription-functions.php
+++ b/bp-activity-subscription-functions.php
@@ -846,6 +846,17 @@ function ass_send_email( $email_type, $to, $args ) {
 		do_action( 'bp_ges_before_bp_send_email', $email_type );
 
 		/**
+		 * Filters the email type that GES uses to send a BuddyPress email.
+		 *
+		 * @since 4.0.0
+		 *
+		 * @param string $email_type Current BP email post type.
+		 * @param array  $args       See bp_send_email()'s third argument for full documentation.
+		 * @param string $to		 Email recipient.
+		 */
+		$email_type = apply_filters( 'ass_send_email_email_type', $email_type, $args, $to );
+
+		/**
 		 * Filter the arguments before GES sends a BuddyPress email.
 		 *
 		 * @since 3.7.0


### PR DESCRIPTION
This allows for more specific `email_type` (ie email templates) to be used based on the specifics of the activity item. For example, this allows you to send all `bbp_topic_create` activity items to a specific template.