### PR TITLE
Fix "update email subscription settings for all members to the default" link

### DIFF
--- a/screen-admin.php
+++ b/screen-admin.php
@@ -90,7 +90,11 @@ function ass_manage_all_members_email_update() {
 			if ( !check_admin_referer( 'ass_change_all_email_sub' ) )
 				return false;
 
-			$result = BP_Groups_Member::get_all_for_group( bp_get_current_group_id(), 0, 0, 0 ); // set the last value to 1 to exclude admins
+			$result = groups_get_group_members( array(
+				'group_id' => bp_get_current_group_id(),
+				'per_page' => 0,
+				'exclude_admins_mods' => false
+			) );
 			$members = $result['members'];
 
 			foreach ( $members as $member ) {


### PR DESCRIPTION
On a group's "Manage > Members" page, there is a link located at the bottom of the page so super admins can change the email subscription for all members of a group.

This link did not change the email subscription for all group members though because the older `BP_Groups_Member::get_all_for_group()` call did not fetch all the group members correctly.

I've replaced that deprecated call with the `groups_get_group_members()` function, which correclty fetches all group members and fixes this issue.