### PR TITLE
Remove BuddyPress legacy forums function check

### DIFF
--- a/bp-activity-subscription-functions.php
+++ b/bp-activity-subscription-functions.php
@@ -2290,10 +2290,9 @@ function ass_get_forum_type() {
 
 		$type = 'bbpress';
 
-	// check for BP's bundled forums
+	// check for BP's bundled legacy forums.
 	} else {
-		// BP's bundled forums aren't installed correctly, so stop!
-		if ( ! bp_is_active( 'forums' ) || ! bp_forums_is_installed_correctly() ) {
+		if ( ! bp_is_active( 'forums' ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
Saw this report on the wp.org forums - https://wordpress.org/support/topic/critical-error-63/

New installs of GES could potentially run into a fatal error if their install does not have the bbPress plugin activated due to the removal of the BP legacy forums and the use of a function that no longer exists.