### PR TITLE
Accessible subscription options panel

### DIFF
--- a/bp-activity-subscription-digest.php
+++ b/bp-activity-subscription-digest.php
@@ -64,6 +64,19 @@ function bpges_process_digest_for_user( $user_id, $type, $timestamp, $is_preview
 
 	$items = $query->get_results();
 
+	/**
+	 * Filters the items to be included in a digest for a user.
+	 *
+	 * @since 3.9.5
+	 *
+	 * @param array  $items      Items returned by BPGES_Queued_Item_Query::get_results().
+	 * @param int    $user_id    ID of the user.
+	 * @param string $type       Digest type. 'sum' or 'dig'.
+	 * @param string $timestamp  Timestamp for the current digest run.
+	 * @param bool   $is_preview Whether this is a preview.
+	 */
+	$items = apply_filters( 'bpges_user_digest_items', $items, $user_id, $type, $timestamp, $is_preview );
+
 	// Sort by group.
 	$sorted_by_group = array();
 	foreach ( $items as $item ) {

--- a/bp-activity-subscription-functions.php
+++ b/bp-activity-subscription-functions.php
@@ -1613,12 +1613,11 @@ function ass_subscribe_translate( $status ){
 
 // Handles AJAX request to subscribe/unsubscribe from group
 function ass_group_ajax_callback() {
-	global $bp;
-	//check_ajax_referer( "ass_group_subscribe" );
-
 	$action = $_POST['a'];
 	$user_id = bp_loggedin_user_id();
 	$group_id = $_POST['group_id'];
+
+	check_ajax_referer( "bpges-sub-{$group_id}" );
 
 	ass_group_subscription( $action, $user_id, $group_id );
 

--- a/bp-activity-subscription-js.js
+++ b/bp-activity-subscription-js.js
@@ -45,7 +45,10 @@ jQuery(document).ready( function($) {
 		var stheid = theid.split('-');
 		group_id = stheid[1];
 		current = $( '#gsubstat-'+group_id ).html();
-		$('#gsubajaxload-'+group_id).toggle();
+		$('#gsubajaxload-'+group_id).css('display','inline-block');
+
+		newBtn = $('button.js-tooltip[data-tooltip-content-id="ges-panel-' + group_id + '"]');
+		newBtn.hide();
 
 		var data = {
 			action: 'ass_group_ajax',
@@ -53,6 +56,8 @@ jQuery(document).ready( function($) {
 			group_id: stheid[1]
 			//,_ajax_nonce: stheid[2]
 		};
+
+		$( '#js-tooltip-close' ).click();
 
 		$.post( ajaxurl, data, function( response ) {
 			status = $(it).html();
@@ -63,7 +68,8 @@ jQuery(document).ready( function($) {
 			$( '#gsubstat-'+group_id ).html( status ); //add .animate({opacity: 1.0}, 2000) to slow things down for testing
 			$( '#gsubstat-'+group_id ).addClass( 'gemail_icon' );
 			$( '#gsubopt-'+group_id ).slideToggle('fast');
-			$( '#gsubajaxload-'+group_id ).toggle();
+			$( '#gsubajaxload-'+group_id ).hide();
+			newBtn.show();
 		});
 
 	});

--- a/bp-activity-subscription-js.js
+++ b/bp-activity-subscription-js.js
@@ -1,13 +1,11 @@
-jQuery(document).ready( function() {
-	var j = jQuery;
-
+jQuery(document).ready( function($) {
 	// topic follow/mute
-	j( document ).on("click", '.ass-topic-subscribe > a', function() {
-		it = j(this);
-		var theid = j(this).attr('id');
+	$( document ).on("click", '.ass-topic-subscribe > a', function() {
+		it = $(this);
+		var theid = $(this).attr('id');
 		var stheid = theid.split('-');
 
-		//j('.pagination .ajax-loader').toggle();
+		//$('.pagination .ajax-loader').toggle();
 
 		var data = {
 			action: 'ass_ajax',
@@ -19,7 +17,7 @@ jQuery(document).ready( function() {
 
 		// TODO: add ajax code to give status feedback that will fade out
 
-		j.post( ajaxurl, data, function( response ) {
+		$.post( ajaxurl, data, function( response ) {
 			if ( response == 'follow' ) {
 				var m = bp_ass.mute;
 				theid = theid.replace( 'follow', 'mute' );
@@ -30,24 +28,24 @@ jQuery(document).ready( function() {
 				var m = bp_ass.error;
 			}
 
-			j(it).html(m);
-			j(it).attr('id', theid);
-			j(it).attr('title', '');
+			$(it).html(m);
+			$(it).attr('id', theid);
+			$(it).attr('title', '');
 
-			//j('.pagination .ajax-loader').toggle();
+			//$('.pagination .ajax-loader').toggle();
 
 		});
 	});
 
 
 	// group subscription options
-	j( document ).on("click", '.group-sub', function() {
-		it = j(this);
-		var theid = j(this).attr('id');
+	$( document ).on("click", '.group-sub', function() {
+		it = $(this);
+		var theid = $(this).attr('id');
 		var stheid = theid.split('-');
 		group_id = stheid[1];
-		current = j( '#gsubstat-'+group_id ).html();
-		j('#gsubajaxload-'+group_id).toggle();
+		current = $( '#gsubstat-'+group_id ).html();
+		$('#gsubajaxload-'+group_id).toggle();
 
 		var data = {
 			action: 'ass_group_ajax',
@@ -56,43 +54,42 @@ jQuery(document).ready( function() {
 			//,_ajax_nonce: stheid[2]
 		};
 
-		j.post( ajaxurl, data, function( response ) {
-			status = j(it).html();
+		$.post( ajaxurl, data, function( response ) {
+			status = $(it).html();
 			if ( !current || current == 'No Email' ) {
-				j( '#gsublink-'+group_id ).html('change');
+				$( '#gsublink-'+group_id ).html('change');
 				//status = status + ' / ';
 			}
-			j( '#gsubstat-'+group_id ).html( status ); //add .animate({opacity: 1.0}, 2000) to slow things down for testing
-			j( '#gsubstat-'+group_id ).addClass( 'gemail_icon' );
-			j( '#gsubopt-'+group_id ).slideToggle('fast');
-			j( '#gsubajaxload-'+group_id ).toggle();
+			$( '#gsubstat-'+group_id ).html( status ); //add .animate({opacity: 1.0}, 2000) to slow things down for testing
+			$( '#gsubstat-'+group_id ).addClass( 'gemail_icon' );
+			$( '#gsubopt-'+group_id ).slideToggle('fast');
+			$( '#gsubajaxload-'+group_id ).toggle();
 		});
 
 	});
 
-	j( document ).on("click", '.group-subscription-options-link', function() {
-		stheid = j(this).attr('id').split('-');
+	$( document ).on("click", '.group-subscription-options-link', function() {
+		stheid = $(this).attr('id').split('-');
 		group_id = stheid[1];
-		j( '#gsubopt-'+group_id ).slideToggle('fast');
+		$( '#gsubopt-'+group_id ).slideToggle('fast');
 	});
 
-	j( document ).on("click", '.group-subscription-close', function() {
-		stheid = j(this).attr('id').split('-');
+	$( document ).on("click", '.group-subscription-close', function() {
+		stheid = $(this).attr('id').split('-');
 		group_id = stheid[1];
-		j( '#gsubopt-'+group_id ).slideToggle('fast');
+		$( '#gsubopt-'+group_id ).slideToggle('fast');
 	});
 
-	//j( document ).on("click", '.ass-settings-advanced-link', function() {
-	//	j( '.ass-settings-advanced' ).slideToggle('fast');
+	//$( document ).on("click", '.ass-settings-advanced-link', function() {
+	//	$( '.ass-settings-advanced' ).slideToggle('fast');
 	//});
 
 	// Toggle welcome email fields on group email options page
-	j( document ).on("change", '#ass-welcome-email-enabled', function() {
-		if ( j(this).prop('checked') ) {
-			j('.ass-welcome-email-field').show();
+	$( document ).on("change", '#ass-welcome-email-enabled', function() {
+		if ( $(this).prop('checked') ) {
+			$('.ass-welcome-email-field').show();
 		} else {
-			j('.ass-welcome-email-field').hide();
+			$('.ass-welcome-email-field').hide();
 		}
 	});
-
 });

--- a/bp-activity-subscription-js.js
+++ b/bp-activity-subscription-js.js
@@ -53,8 +53,8 @@ jQuery(document).ready( function($) {
 		var data = {
 			action: 'ass_group_ajax',
 			a: stheid[0],
-			group_id: stheid[1]
-			//,_ajax_nonce: stheid[2]
+			group_id: stheid[1],
+			_ajax_nonce: it.parent().data( 'security' )
 		};
 
 		$( '#js-tooltip-close' ).click();

--- a/bp-activity-subscription-js.js
+++ b/bp-activity-subscription-js.js
@@ -1,4 +1,22 @@
 jQuery(document).ready( function($) {
+	var groupRow = $( '#groups-list li' );
+
+	if ( groupRow.find( 'div.ges-panel' ).length ) {
+		repositionGESPanel();
+		$( window ).resize(function() {
+			repositionGESPanel();
+		});
+	}
+
+	// If positioned right, ensure panel is aligned right as well.
+	function repositionGESPanel() {
+		if ( 'right' === groupRow.find('div.action').css('float') || 'right' === groupRow.find('div.action, div.item-actions').css('text-align') ) {
+			groupRow.find('.group-subscription-div').addClass( 'ges-panel-right' );
+		} else {
+			groupRow.find('.group-subscription-div').removeClass( 'ges-panel-right' );
+		}
+	}
+
 	// topic follow/mute
 	$( document ).on("click", '.ass-topic-subscribe > a', function() {
 		it = $(this);

--- a/bp-activity-subscription-js.js
+++ b/bp-activity-subscription-js.js
@@ -19,13 +19,14 @@ jQuery(document).ready( function($) {
 
 	// topic follow/mute
 	$( document ).on("click", '.ass-topic-subscribe > a', function() {
-		it = $(this);
-		var theid = $(this).attr('id');
-		var stheid = theid.split('-');
+		var it = $(this),
+			theid = $(this).attr('id'),
+			stheid = theid.split('-'),
+			data;
 
 		//$('.pagination .ajax-loader').toggle();
 
-		var data = {
+		data = {
 			action: 'ass_ajax',
 			a: stheid[0],
 			topic_id: stheid[1],
@@ -36,14 +37,16 @@ jQuery(document).ready( function($) {
 		// TODO: add ajax code to give status feedback that will fade out
 
 		$.post( ajaxurl, data, function( response ) {
+			var m, theid;
+
 			if ( response == 'follow' ) {
-				var m = bp_ass.mute;
+				m = bp_ass.mute;
 				theid = theid.replace( 'follow', 'mute' );
 			} else if ( response == 'mute' ) {
-				var m = bp_ass.follow;
+				m = bp_ass.follow;
 				theid = theid.replace( 'mute', 'follow' );
 			} else {
-				var m = bp_ass.error;
+				m = bp_ass.error;
 			}
 
 			$(it).html(m);
@@ -58,17 +61,18 @@ jQuery(document).ready( function($) {
 
 	// group subscription options
 	$( document ).on("click", '.group-sub', function() {
-		it = $(this);
-		var theid = $(this).attr('id');
-		var stheid = theid.split('-');
-		group_id = stheid[1];
-		current = $( '#gsubstat-'+group_id ).html();
-		$('#gsubajaxload-'+group_id).css('display','inline-block');
+		var it = $(this),
+			theid = $(this).attr('id'),
+			stheid = theid.split('-'),
+			group_id = stheid[1],
+			current = $( '#gsubstat-' + group_id ).html(),
+			newBtn = $('button.js-tooltip[data-tooltip-content-id="ges-panel-' + group_id + '"]'),
+			data;
 
-		newBtn = $('button.js-tooltip[data-tooltip-content-id="ges-panel-' + group_id + '"]');
+		$('#gsubajaxload-' + group_id).css('display','inline-block');
 		newBtn.hide();
 
-		var data = {
+		data = {
 			action: 'ass_group_ajax',
 			a: stheid[0],
 			group_id: stheid[1],
@@ -78,30 +82,32 @@ jQuery(document).ready( function($) {
 		$( '#js-tooltip-close' ).click();
 
 		$.post( ajaxurl, data, function( response ) {
-			status = $(it).html();
+			var status = $(it).html();
 			if ( !current || current == 'No Email' ) {
-				$( '#gsublink-'+group_id ).html('change');
+				$( '#gsublink-' + group_id ).html('change');
 				//status = status + ' / ';
 			}
-			$( '#gsubstat-'+group_id ).html( status ); //add .animate({opacity: 1.0}, 2000) to slow things down for testing
-			$( '#gsubstat-'+group_id ).addClass( 'gemail_icon' );
-			$( '#gsubopt-'+group_id ).slideToggle('fast');
-			$( '#gsubajaxload-'+group_id ).hide();
+			$( '#gsubstat-' + group_id ).html( status ); //add .animate({opacity: 1.0}, 2000) to slow things down for testing
+			$( '#gsubstat-' + group_id ).addClass( 'gemail_icon' );
+			$( '#gsubopt-' + group_id ).slideToggle('fast');
+			$( '#gsubajaxload-' + group_id ).hide();
 			newBtn.show();
 		});
 
 	});
 
 	$( document ).on("click", '.group-subscription-options-link', function() {
-		stheid = $(this).attr('id').split('-');
-		group_id = stheid[1];
-		$( '#gsubopt-'+group_id ).slideToggle('fast');
+		var stheid = $(this).attr('id').split('-'),
+			group_id = stheid[1];
+
+		$( '#gsubopt-' + group_id ).slideToggle('fast');
 	});
 
 	$( document ).on("click", '.group-subscription-close', function() {
-		stheid = $(this).attr('id').split('-');
-		group_id = stheid[1];
-		$( '#gsubopt-'+group_id ).slideToggle('fast');
+		var stheid = $(this).attr('id').split('-'),
+			group_id = stheid[1];
+
+		$( '#gsubopt-' + group_id ).slideToggle('fast');
 	});
 
 	//$( document ).on("click", '.ass-settings-advanced-link', function() {

--- a/bp-activity-subscription-main.php
+++ b/bp-activity-subscription-main.php
@@ -93,7 +93,7 @@ class Group_Activity_Subscription extends BP_Group_Extension {
 
 	public function add_settings_stylesheet() {
 		if ( apply_filters( 'ass_load_assets', bp_is_groups_component() ) ) {
-			$revision_date = '20160516';
+			$revision_date = '20200623';
 
 			wp_register_style(
 				'activity-subscription-style',

--- a/bp-activity-subscription-main.php
+++ b/bp-activity-subscription-main.php
@@ -108,7 +108,7 @@ class Group_Activity_Subscription extends BP_Group_Extension {
 
 	public function ass_add_javascript() {
 		if ( apply_filters( 'ass_load_assets', bp_is_groups_component() ) ) {
-			$revision_date = '20160928';
+			$revision_date = '20200623';
 
 			wp_register_script(
 				'bp-activity-subscription-js',

--- a/css/bp-activity-subscription-css.css
+++ b/css/bp-activity-subscription-css.css
@@ -117,3 +117,130 @@ h4.activity-subscription-settings-title {
 	font-size:11px;
 	color:#888;
 }
+
+/* NEW PANEL ********************************************************/
+
+button.ges-change {
+    font-size: 1em;
+    margin-bottom: 0;
+    margin-left: .4em;
+}
+
+button.ges-change,
+button.ges-change:hover {
+    padding: 3px 6px;
+}
+
+.ges-ajax-processing {
+	background:url(../../buddypress/bp-themes/bp-default/_inc/images/ajax-loader.gif) no-repeat top left;
+	display: none;
+	height: 16px;
+	line-height: 1;
+	margin-left: .4em;
+	vertical-align: middle;
+	width: 16px;
+}
+
+.group-subscription-div #js-dialogtooltip {
+	border: 2px solid #333;
+	border-radius: 4px;
+	padding: 1em;
+	width: max-content;
+	left: 0;
+	right: auto;
+	display: block;
+	z-index: 99999;
+}
+
+.js-dialogtooltip #tooltip-title {
+	font-size: 1em;
+	margin-top: 0;
+	margin-bottom: .6em;
+}
+
+.js-dialogtooltip #tooltip-title:before {
+	display: none;
+}
+
+.js-dialogtooltip #tooltip-title,
+.group-email-tooltip #js-tooltip-content {
+	text-align: left;
+}
+
+.group-subscription-div #js-tooltip-close {
+	float: right;
+	font-size: 1em;
+	margin-top: 0;
+}
+
+#js-dialogtooltip button {
+	font-weight: bold;
+	line-height: 1;
+	margin-left: 4px;
+	padding: 3px 6px !important;
+}
+
+.group-email-tooltip a {
+	display: inline-block;
+	margin-bottom: .5em;
+	margin-right: .4em;
+	width: auto;
+}
+
+.group-email-tooltip :focus {
+	box-shadow: 0 0 5px rgba(69, 105, 185, 1);
+}
+
+.group-subscription-div {
+	position: relative;
+}
+
+body.bp-nouveau.groups:not(.single-item) .group-subscription-div {
+	position: initial;
+}
+
+body.bp-nouveau.groups:not(.single-item) .group-subscription-div #js-dialogtooltip {
+	left: 0;
+	right: 0;
+}
+
+@media screen and (min-width: 46.8em) {
+	body.bp-nouveau.groups:not(.single-item) .group-subscription-div #js-dialogtooltip {
+		left: calc(150px + 5%);
+		right: auto;
+	}
+}
+
+/* fixes for older themes */
+
+body.bp-legacy #item-header-content .ges-panel {
+	position: absolute;
+}
+
+#bp-default #item-header-content .ges-panel,
+#infinity-base #item-header-content .ges-panel {
+	position: initial;
+}
+
+#bp-default #item-header-content .ges-panel #js-dialogtooltip {
+	left: 190px;
+}
+
+#infinity-base #item-header-content .ges-panel #js-dialogtooltip {
+	left: 30px;
+}
+
+body.bp-legacy:not(#bp-default):not(#infinity-base) #groups-list .ges-panel #js-dialogtooltip {
+	position: relative;
+}
+
+body.bp-legacy #buddypress div.action .ges-panel #js-dialogtooltip div {
+	clear: none;
+	float: none;
+	margin-bottom: 0;
+}
+
+body.bp-legacy #buddypress div.action .ges-panel #js-dialogtooltip a {
+	display: inline-block;
+	width: auto;
+}

--- a/css/bp-activity-subscription-css.css
+++ b/css/bp-activity-subscription-css.css
@@ -209,6 +209,13 @@ body.bp-nouveau.groups:not(.single-item) .group-subscription-div #js-dialogtoolt
 	right: 0;
 }
 
+@media screen and (max-width: 782px) {
+	body.bp-nouveau.groups #item-header-cover-image #item-header-content #js-dialogtooltip {
+		left: 0;
+		right: 0;
+	}
+}
+
 @media screen and (min-width: 46.8em) {
 	body.bp-nouveau.groups:not(.single-item) .group-subscription-div #js-dialogtooltip {
 		left: calc(150px + 5%);

--- a/css/bp-activity-subscription-css.css
+++ b/css/bp-activity-subscription-css.css
@@ -152,6 +152,11 @@ button.ges-change:hover {
 	z-index: 99999;
 }
 
+.ges-panel-right #js-dialogtooltip {
+	left: auto !important;
+	right: 0 !important;
+}
+
 .js-dialogtooltip #tooltip-title {
 	font-size: 1em;
 	margin-top: 0;

--- a/readme.txt
+++ b/readme.txt
@@ -93,6 +93,11 @@ For bug reports or to add patches or translation files, please visit the [GES Gi
 
 == Changelog ==
 
+= 3.9.5 =
+* Fix bug that could cause incorrect information to be pulled for bp-groupblog activity items.
+* Fix bug that can cause empty upload directories to be created in some cases.
+* Improved stylability for View links in digests.
+
 = 3.9.4 =
 * Fix bug that could trigger fatal errors in some upgrade situations.
 

--- a/screen.php
+++ b/screen.php
@@ -114,19 +114,22 @@ function ass_group_subscribe_button() {
 	</div>
 
 	<div id="<?php echo $container_id; ?>" style="display:none;" <?php echo $container_classes; ?>>
-		<a class="group-sub" id="no-<?php echo $group->id; ?>" href="javascript:;"><?php esc_html_e( 'No Email', 'buddypress-group-email-subscription' ); ?></a> <?php esc_html_e( 'I will read this group on the web', 'buddypress-group-email-subscription' ); ?><br>
-		<a class="group-sub" id="sum-<?php echo $group->id; ?>" href="javascript:;"><?php esc_html_e( 'Weekly Summary', 'buddypress-group-email-subscription' ); ?></a> <?php esc_html_e( 'Get a summary of topics each', 'buddypress-group-email-subscription' ); ?> <?php echo ass_weekly_digest_week(); ?><br>
-		<a class="group-sub" id="dig-<?php echo $group->id; ?>" href="javascript:;"><?php esc_html_e( 'Daily Digest', 'buddypress-group-email-subscription' ); ?></a> <?php esc_html_e( 'Get the day\'s activity bundled into one email', 'buddypress-group-email-subscription' ); ?><br>
+		<div data-security="<?php echo wp_create_nonce( 'bpges-sub-' . $group->id ); ?>">
+			<a class="group-sub" id="no-<?php echo $group->id; ?>" href="javascript:;"><?php esc_html_e( 'No Email', 'buddypress-group-email-subscription' ); ?></a> <?php esc_html_e( 'I will read this group on the web', 'buddypress-group-email-subscription' ); ?><br>
+			<a class="group-sub" id="sum-<?php echo $group->id; ?>" href="javascript:;"><?php esc_html_e( 'Weekly Summary', 'buddypress-group-email-subscription' ); ?></a> <?php esc_html_e( 'Get a summary of topics each', 'buddypress-group-email-subscription' ); ?> <?php echo ass_weekly_digest_week(); ?><br>
+			<a class="group-sub" id="dig-<?php echo $group->id; ?>" href="javascript:;"><?php esc_html_e( 'Daily Digest', 'buddypress-group-email-subscription' ); ?></a> <?php esc_html_e( 'Get the day\'s activity bundled into one email', 'buddypress-group-email-subscription' ); ?><br>
 
-		<?php if ( ass_get_forum_type() ) : ?>
-			<a class="group-sub" id="sub-<?php echo $group->id; ?>" href="javascript:;"><?php esc_html_e( 'New Topics', 'buddypress-group-email-subscription' ); ?></a> <?php esc_html_e( 'Send new topics as they arrive (but no replies)', 'buddypress-group-email-subscription' ); ?><br>
-		<?php endif; ?>
+			<?php if ( ass_get_forum_type() ) : ?>
+				<a class="group-sub" id="sub-<?php echo $group->id; ?>" href="javascript:;"><?php esc_html_e( 'New Topics', 'buddypress-group-email-subscription' ); ?></a> <?php esc_html_e( 'Send new topics as they arrive (but no replies)', 'buddypress-group-email-subscription' ); ?><br>
+			<?php endif; ?>
 
-		<a class="group-sub" id="supersub-<?php echo $group->id; ?>" href="javascript:;"><?php esc_html_e( 'All Email', 'buddypress-group-email-subscription' ); ?></a> <?php esc_html_e( 'Send all group activity as it arrives', 'buddypress-group-email-subscription' ); ?>
+			<a class="group-sub" id="supersub-<?php echo $group->id; ?>" href="javascript:;"><?php esc_html_e( 'All Email', 'buddypress-group-email-subscription' ); ?></a> <?php esc_html_e( 'Send all group activity as it arrives', 'buddypress-group-email-subscription' ); ?>
 
-		<?php if ( ! bpges_use_new_options_panel() ) : ?>
-			<br><a class="group-subscription-close" id="gsubclose-<?php echo $group->id; ?>"><?php esc_html_e( 'Close', 'buddypress-group-email-subscription' ); ?></a>
-		<?php endif; ?>
+			<?php if ( ! bpges_use_new_options_panel() ) : ?>
+				<br><a class="group-subscription-close" id="gsubclose-<?php echo $group->id; ?>"><?php esc_html_e( 'Close', 'buddypress-group-email-subscription' ); ?></a>
+			<?php endif; ?>
+
+		</div>
 	</div>
 
 	<?php

--- a/screen.php
+++ b/screen.php
@@ -71,14 +71,14 @@ function ass_group_subscribe_button() {
 	if ( $group_status == 'no' )
 		$group_status = NULL;
 
-	$status_desc = __('Your email status is ', 'buddypress-group-email-subscription');
-	$link_text = __('change', 'buddypress-group-email-subscription');
+	$status_desc = esc_html__( 'Your email status is ', 'buddypress-group-email-subscription' );
+	$link_text = esc_html__( 'change', 'buddypress-group-email-subscription' );
 	$gemail_icon_class = ' gemail_icon';
 	$sep = '';
 
 	if ( !$group_status ) {
 		//$status_desc = '';
-		$link_text = __('Get email updates', 'buddypress-group-email-subscription');
+		$link_text = esc_html__( 'Get email updates', 'buddypress-group-email-subscription' );
 		$gemail_icon_class = '';
 		$sep = '';
 	}
@@ -89,20 +89,20 @@ function ass_group_subscribe_button() {
 	<div class="group-subscription-div">
 		<span class="group-subscription-status-desc"><?php echo $status_desc; ?></span>
 		<span class="group-subscription-status<?php echo $gemail_icon_class ?>" id="gsubstat-<?php echo $group->id; ?>"><?php echo $status; ?></span> <?php echo $sep; ?>
-		(<a class="group-subscription-options-link" id="gsublink-<?php echo $group->id; ?>" href="javascript:void(0);" title="<?php _e('Change your email subscription options for this group','buddypress-group-email-subscription');?>"><?php echo $link_text; ?></a>)
+		(<a class="group-subscription-options-link" id="gsublink-<?php echo $group->id; ?>" href="javascript:void(0);" title="<?php esc_html_e( 'Change your email subscription options for this group', 'buddypress-group-email-subscription' ); ?>"><?php echo $link_text; ?></a>)
 		<span class="ajax-loader" id="gsubajaxload-<?php echo $group->id; ?>"></span>
 	</div>
 	<div class="generic-button group-subscription-options" id="gsubopt-<?php echo $group->id; ?>" style="display:none;">
-		<a class="group-sub" id="no-<?php echo $group->id; ?>"><?php _e('No Email', 'buddypress-group-email-subscription') ?></a> <?php _e('I will read this group on the web', 'buddypress-group-email-subscription') ?><br>
-		<a class="group-sub" id="sum-<?php echo $group->id; ?>"><?php _e('Weekly Summary', 'buddypress-group-email-subscription') ?></a> <?php _e('Get a summary of topics each', 'buddypress-group-email-subscription') ?> <?php echo ass_weekly_digest_week(); ?><br>
-		<a class="group-sub" id="dig-<?php echo $group->id; ?>"><?php _e('Daily Digest', 'buddypress-group-email-subscription') ?></a> <?php _e('Get the day\'s activity bundled into one email', 'buddypress-group-email-subscription') ?><br>
+		<a class="group-sub" id="no-<?php echo $group->id; ?>" href="javascript:;"><?php esc_html_e( 'No Email', 'buddypress-group-email-subscription' ); ?></a> <?php esc_html_e( 'I will read this group on the web', 'buddypress-group-email-subscription' ); ?><br>
+		<a class="group-sub" id="sum-<?php echo $group->id; ?>" href="javascript:;"><?php esc_html_e( 'Weekly Summary', 'buddypress-group-email-subscription' ); ?></a> <?php esc_html_e( 'Get a summary of topics each', 'buddypress-group-email-subscription' ); ?> <?php echo ass_weekly_digest_week(); ?><br>
+		<a class="group-sub" id="dig-<?php echo $group->id; ?>" href="javascript:;"><?php esc_html_e( 'Daily Digest', 'buddypress-group-email-subscription' ); ?></a> <?php esc_html_e( 'Get the day\'s activity bundled into one email', 'buddypress-group-email-subscription' ); ?><br>
 
 		<?php if ( ass_get_forum_type() ) : ?>
-			<a class="group-sub" id="sub-<?php echo $group->id; ?>"><?php _e('New Topics', 'buddypress-group-email-subscription') ?></a> <?php _e('Send new topics as they arrive (but no replies)', 'buddypress-group-email-subscription') ?><br>
+			<a class="group-sub" id="sub-<?php echo $group->id; ?>" href="javascript:;"><?php esc_html_e( 'New Topics', 'buddypress-group-email-subscription' ); ?></a> <?php esc_html_e( 'Send new topics as they arrive (but no replies)', 'buddypress-group-email-subscription' ); ?><br>
 		<?php endif; ?>
 
-		<a class="group-sub" id="supersub-<?php echo $group->id; ?>"><?php _e('All Email', 'buddypress-group-email-subscription') ?></a> <?php _e('Send all group activity as it arrives', 'buddypress-group-email-subscription') ?><br>
-		<a class="group-subscription-close" id="gsubclose-<?php echo $group->id; ?>"><?php _e('close', 'buddypress-group-email-subscription') ?></a>
+		<a class="group-sub" id="supersub-<?php echo $group->id; ?>" href="javascript:;"><?php esc_html_e( 'All Email', 'buddypress-group-email-subscription' ); ?></a> <?php esc_html_e( 'Send all group activity as it arrives', 'buddypress-group-email-subscription' ); ?><br>
+		<a class="group-subscription-close" id="gsubclose-<?php echo $group->id; ?>"><?php esc_html_e( 'Close', 'buddypress-group-email-subscription' ); ?></a>
 	</div>
 
 	<?php

--- a/screen.php
+++ b/screen.php
@@ -5,6 +5,49 @@
  * @since 3.7.0
  */
 
+/**
+ * Should we use the new options panel?
+ *
+ * @since 4.0.0
+ *
+ * @return bool
+ */
+function bpges_use_new_options_panel() {
+
+	/**
+	 * Whether to enable the new options panel.
+	 *
+	 * Those using the BP Nouveau template pack or the older bp-default theme
+	 * will use the new options panel by default. bp-legacy will not due to
+	 * layout issues, however can be forced to true with this filter. CSS
+	 * will need to adjusted manually though.
+	 *
+	 * @since 4.0.0
+	 *
+	 * @param bool $retval True for Nouveau or bp-default themes.
+	 */
+	$retval = apply_filters( 'bpges_use_new_options_panel', function_exists( 'bp_nouveau' ) || current_theme_supports( 'buddypress' ) );
+
+	return $retval;
+}
+
+/**
+ * Enqueues van11y-accessible-modal-tooltip-aria.
+ *
+ * Used for new options panel.
+ *
+ * @since 4.0.0
+ *
+ * @link https://github.com/nico3333fr/van11y-accessible-modal-tooltip-aria/blob/master/LICENSE
+ */
+add_action( 'bp_enqueue_scripts', function() {
+	if ( ! bpges_use_new_options_panel() ) {
+		return;
+	}
+
+	wp_enqueue_script( 'van11y-accessible-modal-tooltip-aria', 'https://cdn.rawgit.com/nico3333fr/van11y-accessible-modal-tooltip-aria/e3518090/dist/van11y-accessible-modal-tooltip-aria.min.js' );
+}, 9 );
+
 // this adds the ajax-based subscription option in the group header, or group directory
 function ass_group_subscribe_button() {
 	global $bp, $groups_template;

--- a/screen.php
+++ b/screen.php
@@ -84,15 +84,36 @@ function ass_group_subscribe_button() {
 	}
 
 	$status = ass_subscribe_translate( $group_status );
+
+	if ( bpges_use_new_options_panel() ) {
+		$container_id = 'ges-panel-' . $group->id;
+		$container_classes = '';
+		$ajax_class = 'ges-ajax-processing';
+	} else {
+		$container_id = 'gsubopt-' . $group->id;
+		$container_classes = ' class="generic-button group-subscription-options"';
+		$ajax_class = 'ajax-loader';
+	}
 	?>
 
-	<div class="group-subscription-div">
+	<div class="group-subscription-div <?php echo bpges_use_new_options_panel() && ! function_exists( 'bp_nouveau' ) ? 'ges-panel' : ''; ?>">
 		<span class="group-subscription-status-desc"><?php echo $status_desc; ?></span>
 		<span class="group-subscription-status<?php echo $gemail_icon_class ?>" id="gsubstat-<?php echo $group->id; ?>"><?php echo $status; ?></span> <?php echo $sep; ?>
-		(<a class="group-subscription-options-link" id="gsublink-<?php echo $group->id; ?>" href="javascript:void(0);" title="<?php esc_html_e( 'Change your email subscription options for this group', 'buddypress-group-email-subscription' ); ?>"><?php echo $link_text; ?></a>)
-		<span class="ajax-loader" id="gsubajaxload-<?php echo $group->id; ?>"></span>
+
+		<?php if ( bpges_use_new_options_panel() ) : ?>
+
+			<button class="js-tooltip ges-change" id="gestoggle-<?php echo $group->id; ?>" data-tooltip-content-id="ges-panel-<?php echo $group->id; ?>" data-tooltip-prefix-class="group-email" data-tooltip-title="<?php esc_html_e( 'Change email subscription for this group', 'buddypress-group-email-subscription' ); ?>" data-tooltip-close-text="<?php esc_html_e( 'Close', 'buddypress-group-email-subscription' ); ?>" data-tooltip-close-title="<?php esc_html_e( 'Close this window', 'buddypress-group-email-subscription' ); ?>"><?php esc_html_e( 'Change', 'buddypress-group-email-subscription' ); ?></button>
+
+		<?php else : ?>
+
+			(<a class="group-subscription-options-link js-tooltip" id="gestoggle-<?php echo $group->id; ?>" data-tooltip-content-id="ges-panel-<?php echo $group->id; ?>" data-tooltip-prefix-class="group-email" data-tooltip-title="<?php esc_html_e( 'Change email subscription for this group', 'buddypress-group-email-subscription' ); ?>" data-tooltip-close-text="<?php esc_html_e( 'Close', 'buddypress-group-email-subscription' ); ?>" data-tooltip-close-title="<?php esc_html_e( 'Close this window', 'buddypress-group-email-subscription' ); ?>" href="javascript:void(0);"><?php echo $link_text; ?></a>)
+
+		<?php endif; ?>
+
+		<span class="<?php echo $ajax_class; ?>" id="gsubajaxload-<?php echo $group->id; ?>"></span>
 	</div>
-	<div class="generic-button group-subscription-options" id="gsubopt-<?php echo $group->id; ?>" style="display:none;">
+
+	<div id="<?php echo $container_id; ?>" style="display:none;" <?php echo $container_classes; ?>>
 		<a class="group-sub" id="no-<?php echo $group->id; ?>" href="javascript:;"><?php esc_html_e( 'No Email', 'buddypress-group-email-subscription' ); ?></a> <?php esc_html_e( 'I will read this group on the web', 'buddypress-group-email-subscription' ); ?><br>
 		<a class="group-sub" id="sum-<?php echo $group->id; ?>" href="javascript:;"><?php esc_html_e( 'Weekly Summary', 'buddypress-group-email-subscription' ); ?></a> <?php esc_html_e( 'Get a summary of topics each', 'buddypress-group-email-subscription' ); ?> <?php echo ass_weekly_digest_week(); ?><br>
 		<a class="group-sub" id="dig-<?php echo $group->id; ?>" href="javascript:;"><?php esc_html_e( 'Daily Digest', 'buddypress-group-email-subscription' ); ?></a> <?php esc_html_e( 'Get the day\'s activity bundled into one email', 'buddypress-group-email-subscription' ); ?><br>
@@ -101,8 +122,11 @@ function ass_group_subscribe_button() {
 			<a class="group-sub" id="sub-<?php echo $group->id; ?>" href="javascript:;"><?php esc_html_e( 'New Topics', 'buddypress-group-email-subscription' ); ?></a> <?php esc_html_e( 'Send new topics as they arrive (but no replies)', 'buddypress-group-email-subscription' ); ?><br>
 		<?php endif; ?>
 
-		<a class="group-sub" id="supersub-<?php echo $group->id; ?>" href="javascript:;"><?php esc_html_e( 'All Email', 'buddypress-group-email-subscription' ); ?></a> <?php esc_html_e( 'Send all group activity as it arrives', 'buddypress-group-email-subscription' ); ?><br>
-		<a class="group-subscription-close" id="gsubclose-<?php echo $group->id; ?>"><?php esc_html_e( 'Close', 'buddypress-group-email-subscription' ); ?></a>
+		<a class="group-sub" id="supersub-<?php echo $group->id; ?>" href="javascript:;"><?php esc_html_e( 'All Email', 'buddypress-group-email-subscription' ); ?></a> <?php esc_html_e( 'Send all group activity as it arrives', 'buddypress-group-email-subscription' ); ?>
+
+		<?php if ( ! bpges_use_new_options_panel() ) : ?>
+			<br><a class="group-subscription-close" id="gsubclose-<?php echo $group->id; ?>"><?php esc_html_e( 'Close', 'buddypress-group-email-subscription' ); ?></a>
+		<?php endif; ?>
 	</div>
 
 	<?php

--- a/screen.php
+++ b/screen.php
@@ -71,62 +71,65 @@ function ass_group_subscribe_button() {
 	if ( $group_status == 'no' )
 		$group_status = NULL;
 
-	$status_desc = esc_html__( 'Your email status is ', 'buddypress-group-email-subscription' );
-	$link_text = esc_html__( 'change', 'buddypress-group-email-subscription' );
-	$gemail_icon_class = ' gemail_icon';
-	$sep = '';
+	$status_desc = __( 'Your email status is ', 'buddypress-group-email-subscription' );
+	$link_text   = __( 'change', 'buddypress-group-email-subscription' );
 
-	if ( !$group_status ) {
+	$gemail_icon_class = ' gemail_icon';
+	$sep               = '';
+
+	if ( ! $group_status ) {
 		//$status_desc = '';
-		$link_text = esc_html__( 'Get email updates', 'buddypress-group-email-subscription' );
+		$link_text         = __( 'Get email updates', 'buddypress-group-email-subscription' );
 		$gemail_icon_class = '';
-		$sep = '';
 	}
 
 	$status = ass_subscribe_translate( $group_status );
 
 	if ( bpges_use_new_options_panel() ) {
-		$container_id = 'ges-panel-' . $group->id;
+		$container_id      = 'ges-panel-' . $group->id;
 		$container_classes = '';
-		$ajax_class = 'ges-ajax-processing';
+		$ajax_class        = 'ges-ajax-processing';
 	} else {
-		$container_id = 'gsubopt-' . $group->id;
-		$container_classes = ' class="generic-button group-subscription-options"';
-		$ajax_class = 'ajax-loader';
+		$container_id      = 'gsubopt-' . $group->id;
+		$container_classes = 'generic-button group-subscription-options';
+		$ajax_class        = 'ajax-loader';
 	}
+
+	$ges_panel_class = bpges_use_new_options_panel() && ! function_exists( 'bp_nouveau' ) ? 'ges-panel' : '';
+
 	?>
 
-	<div class="group-subscription-div <?php echo bpges_use_new_options_panel() && ! function_exists( 'bp_nouveau' ) ? 'ges-panel' : ''; ?>">
-		<span class="group-subscription-status-desc"><?php echo $status_desc; ?></span>
-		<span class="group-subscription-status<?php echo $gemail_icon_class ?>" id="gsubstat-<?php echo $group->id; ?>"><?php echo $status; ?></span> <?php echo $sep; ?>
+	<div class="group-subscription-div <?php echo esc_attr( $ges_panel_class ); ?>">
+		<span class="group-subscription-status-desc"><?php echo esc_html( $status_desc ); ?></span>
+		<span class="group-subscription-status<?php echo esc_attr( $gemail_icon_class ); ?>" id="gsubstat-<?php echo esc_attr( $group->id ); ?>"><?php echo esc_html( $status ); ?></span> <?php echo esc_html( $sep ); ?>
 
 		<?php if ( bpges_use_new_options_panel() ) : ?>
 
-			<button class="js-tooltip ges-change" id="gestoggle-<?php echo $group->id; ?>" data-tooltip-content-id="ges-panel-<?php echo $group->id; ?>" data-tooltip-prefix-class="group-email" data-tooltip-title="<?php esc_html_e( 'Change email subscription for this group', 'buddypress-group-email-subscription' ); ?>" data-tooltip-close-text="<?php esc_html_e( 'Close', 'buddypress-group-email-subscription' ); ?>" data-tooltip-close-title="<?php esc_html_e( 'Close this window', 'buddypress-group-email-subscription' ); ?>"><?php esc_html_e( 'Change', 'buddypress-group-email-subscription' ); ?></button>
+			<button class="js-tooltip ges-change" id="gestoggle-<?php echo esc_attr( $group->id ); ?>" data-tooltip-content-id="ges-panel-<?php echo esc_attr( $group->id ); ?>" data-tooltip-prefix-class="group-email" data-tooltip-title="<?php esc_html_e( 'Change email subscription for this group', 'buddypress-group-email-subscription' ); ?>" data-tooltip-close-text="<?php esc_html_e( 'Close', 'buddypress-group-email-subscription' ); ?>" data-tooltip-close-title="<?php esc_html_e( 'Close this window', 'buddypress-group-email-subscription' ); ?>"><?php esc_html_e( 'Change', 'buddypress-group-email-subscription' ); ?></button>
 
 		<?php else : ?>
 
-			(<a class="group-subscription-options-link js-tooltip" id="gestoggle-<?php echo $group->id; ?>" data-tooltip-content-id="ges-panel-<?php echo $group->id; ?>" data-tooltip-prefix-class="group-email" data-tooltip-title="<?php esc_html_e( 'Change email subscription for this group', 'buddypress-group-email-subscription' ); ?>" data-tooltip-close-text="<?php esc_html_e( 'Close', 'buddypress-group-email-subscription' ); ?>" data-tooltip-close-title="<?php esc_html_e( 'Close this window', 'buddypress-group-email-subscription' ); ?>" href="javascript:void(0);"><?php echo $link_text; ?></a>)
+			(<a class="group-subscription-options-link js-tooltip" id="gestoggle-<?php echo esc_attr( $group->id ); ?>" data-tooltip-content-id="ges-panel-<?php echo esc_attr( $group->id ); ?>" data-tooltip-prefix-class="group-email" data-tooltip-title="<?php esc_html_e( 'Change email subscription for this group', 'buddypress-group-email-subscription' ); ?>" data-tooltip-close-text="<?php esc_html_e( 'Close', 'buddypress-group-email-subscription' ); ?>" data-tooltip-close-title="<?php esc_html_e( 'Close this window', 'buddypress-group-email-subscription' ); ?>" href="javascript:void(0);"><?php echo esc_html( $link_text ); ?></a>)
 
 		<?php endif; ?>
 
-		<span class="<?php echo $ajax_class; ?>" id="gsubajaxload-<?php echo $group->id; ?>"></span>
+		<span class="<?php echo esc_attr( $ajax_class ); ?>" id="gsubajaxload-<?php echo esc_attr( $group->id ); ?>"></span>
 	</div>
 
-	<div id="<?php echo $container_id; ?>" style="display:none;" <?php echo $container_classes; ?>>
-		<div data-security="<?php echo wp_create_nonce( 'bpges-sub-' . $group->id ); ?>">
-			<a class="group-sub" id="no-<?php echo $group->id; ?>" href="javascript:;"><?php esc_html_e( 'No Email', 'buddypress-group-email-subscription' ); ?></a> <?php esc_html_e( 'I will read this group on the web', 'buddypress-group-email-subscription' ); ?><br>
-			<a class="group-sub" id="sum-<?php echo $group->id; ?>" href="javascript:;"><?php esc_html_e( 'Weekly Summary', 'buddypress-group-email-subscription' ); ?></a> <?php esc_html_e( 'Get a summary of topics each', 'buddypress-group-email-subscription' ); ?> <?php echo ass_weekly_digest_week(); ?><br>
-			<a class="group-sub" id="dig-<?php echo $group->id; ?>" href="javascript:;"><?php esc_html_e( 'Daily Digest', 'buddypress-group-email-subscription' ); ?></a> <?php esc_html_e( 'Get the day\'s activity bundled into one email', 'buddypress-group-email-subscription' ); ?><br>
+	<div id="<?php echo esc_attr( $container_id ); ?>" style="display:none;" class="<?php echo esc_attr( $container_classes ); ?>">
+		<div data-security="<?php echo esc_attr( wp_create_nonce( 'bpges-sub-' . $group->id ) ); ?>">
+			<a class="group-sub" id="no-<?php echo esc_attr( $group->id ); ?>" href="javascript:;"><?php esc_html_e( 'No Email', 'buddypress-group-email-subscription' ); ?></a> <?php esc_html_e( 'I will read this group on the web', 'buddypress-group-email-subscription' ); ?><br>
+			<a class="group-sub" id="sum-<?php echo esc_attr( $group->id ); ?>" href="javascript:;"><?php esc_html_e( 'Weekly Summary', 'buddypress-group-email-subscription' ); ?></a> <?php esc_html_e( 'Get a summary of topics each', 'buddypress-group-email-subscription' ); ?> <?php echo ass_weekly_digest_week(); ?><br>
+			<a class="group-sub" id="dig-<?php echo esc_attr( $group->id ); ?>" href="javascript:;"><?php esc_html_e( 'Daily Digest', 'buddypress-group-email-subscription' ); ?></a> <?php esc_html_e( 'Get the day\'s activity bundled into one email', 'buddypress-group-email-subscription' ); ?><br>
 
 			<?php if ( ass_get_forum_type() ) : ?>
-				<a class="group-sub" id="sub-<?php echo $group->id; ?>" href="javascript:;"><?php esc_html_e( 'New Topics', 'buddypress-group-email-subscription' ); ?></a> <?php esc_html_e( 'Send new topics as they arrive (but no replies)', 'buddypress-group-email-subscription' ); ?><br>
+				<a class="group-sub" id="sub-<?php echo esc_attr( $group->id ); ?>" href="javascript:;"><?php esc_html_e( 'New Topics', 'buddypress-group-email-subscription' ); ?></a> <?php esc_html_e( 'Send new topics as they arrive (but no replies)', 'buddypress-group-email-subscription' ); ?><br>
 			<?php endif; ?>
 
-			<a class="group-sub" id="supersub-<?php echo $group->id; ?>" href="javascript:;"><?php esc_html_e( 'All Email', 'buddypress-group-email-subscription' ); ?></a> <?php esc_html_e( 'Send all group activity as it arrives', 'buddypress-group-email-subscription' ); ?>
+			<a class="group-sub" id="supersub-<?php echo esc_attr( $group->id ); ?>" href="javascript:;"><?php esc_html_e( 'All Email', 'buddypress-group-email-subscription' ); ?></a> <?php esc_html_e( 'Send all group activity as it arrives', 'buddypress-group-email-subscription' ); ?>
 
 			<?php if ( ! bpges_use_new_options_panel() ) : ?>
-				<br><a class="group-subscription-close" id="gsubclose-<?php echo $group->id; ?>"><?php esc_html_e( 'Close', 'buddypress-group-email-subscription' ); ?></a>
+				<br><a class="group-subscription-close" id="gsubclose-<?php echo esc_attr( $group->id ); ?>"><?php esc_html_e( 'Close', 'buddypress-group-email-subscription' ); ?></a>
 			<?php endif; ?>
 
 		</div>


### PR DESCRIPTION
This PR implements a new subscription options panel.

It uses the Van11y Accessible Modal Tooltip JS script:
https://github.com/nico3333fr/van11y-accessible-modal-tooltip-aria

Which means that the options panel is accessible via keyboard. The options can be navigated by tabbing through the options.

![GIF of Options Panel using keyboard](https://user-images.githubusercontent.com/505921/85660412-1e27b800-b6a5-11ea-9c64-34bf3a472c2b.gif)

The new options panel is enabled by default for those using BP Nouveau and the older bp-default theme.

I did test the new options panel against all default WordPress Twenty themes as well and made the decision to disable it for the BP Legacy template pack due to layout issues (`overflow:hidden` for list items). However, you can force-enable the new options panel with a filter:

    add_filter( 'bpges_use_new_options_panel', '__return_true' ); // Use '__return_false' to revert to the older panel.

I've added some CSS for bp-legacy in case people wanted to enable it with bp-legacy, but it's not perfect.

PR should also address #177 to some extent. Default CSS could use some additional tweaking as well.

Ive also added AJAX nonce verification, which was previously missing.

Lastly, I initially based the branch for this PR off of `3.9.x` branch, but decided to move the feature to `4.0.x`. So you should be looking at the commits from June, while ignoring the rest.

Feedback welcome.