### PR TITLE
Run digest content through `wpautop()`.

### DIFF
--- a/bp-activity-subscription-digest.php
+++ b/bp-activity-subscription-digest.php
@@ -591,6 +591,9 @@ function ass_digest_filter( $item ) {
 	return $item;
 }
 
+// Run activity content in digests through wpautop for proper handling of line breaks.
+add_filter( 'ass_digest_content', 'wpautop' );
+
 // convert the email to plain text, and fancy it up a bit. these conversion only work in English, but it's ok.
 function ass_convert_html_to_plaintext( $message ) {
 	// convert view links to http:// links


### PR DESCRIPTION
See #166 

I'm choosing to use `add_filter()` instead of an inline call to `wpautop` in case anyone wants to change the behavior. @r-a-y This seem OK to you?