### PR TITLE
Remove queued items for non-existing user when processing digest

### DIFF
--- a/bp-activity-subscription-digest.php
+++ b/bp-activity-subscription-digest.php
@@ -146,6 +146,10 @@ function bpges_generate_digest( $user_id, $type, $group_activity_ids, $is_previe
 	$summary = $activity_message = $body = '';
 
 	$userdata = new WP_User( $user_id );
+	if ( 0 === $userdata->ID ) {
+		return $group_activity_ids;
+	}
+
 	$to = $userdata->user_email;
 	$userdomain = bp_core_get_user_domain( $user_id );
 
@@ -209,7 +213,7 @@ function bpges_generate_digest( $user_id, $type, $group_activity_ids, $is_previe
 
 	// If there's nothing to send, skip this use.
 	if ( ! $has_group_activity ) {
-		return;
+		return $group_activity_ids;
 	}
 
 	// show group summary for digest, and follow help text for weekly summary
@@ -257,7 +261,7 @@ function bpges_generate_digest( $user_id, $type, $group_activity_ids, $is_previe
 	 */
 	$send = apply_filters( 'bp_ges_send_digest_to_user', true, $user_id, $group_activity_ids, $message );
 	if ( ! $send ) {
-		return;
+		return $group_activity_ids;
 	}
 
 	// Sending time!

--- a/tests/testcases/deletion.php
+++ b/tests/testcases/deletion.php
@@ -99,4 +99,36 @@ class BPGES_Tests_Deletion extends BP_UnitTestCase {
 
 		$this->assertEqualSets( array(), $found );
 	}
+
+	public function test_nonexisting_user_should_delete_queued_items_when_processing_digest() {
+		// This user does not exist.
+		$u = 12345;
+
+		$g = self::factory()->group->create();
+
+		// Create some activity items.
+		$activity_ids = self::factory()->activity->create_many(
+			2,
+			array(
+				'user_id'   => get_current_user_id(),
+				'component' => 'groups',
+				'type'      => 'activity_update',
+				'item_id'   => $g,
+			)
+		);
+
+		// Add activity items to digest for our user.
+		foreach( $activity_ids as $activity_id ) {
+			ass_queue_activity_item( $activity_id, $u, $g, 'sum' );
+		}
+
+		// Process digest.
+		bpges_process_digest_for_user( $u, 'sum', gmdate( 'Y-m-d H:i:s', strtotime( '+1 week' ) ) );
+
+		// Queued items should no longer exist.
+		$query = new BPGES_Queued_Item_Query( array(
+			'user_id' => $u
+		) );
+		$this->assertEmpty( $query->get_results() );
+	}
 }


### PR DESCRIPTION
Reported here: https://wordpress.org/support/topic/deleting-users-does-not-remove-them-from-a-subscription/

The problem is in `bpges_generate_digest()`, we do not check if the user still exists when generating the digest:
https://github.com/boonebgorges/buddypress-group-email-subscription/blob/48444c2056e0c4ace11b3dd7f5fbfefe389a9524/bp-activity-subscription-digest.php#L148

So that function carries on and attempts to send an email to an empty user.

Also when bailing out of this function, we need to return the group activity IDs to ensure that the cleanup routine in `bpges_process_digest_for_user()` is triggered:
https://github.com/boonebgorges/buddypress-group-email-subscription/blob/48444c2056e0c4ace11b3dd7f5fbfefe389a9524/bp-activity-subscription-digest.php#L115-L117

----

I also wrote a test to see if queued items were removed after a user is deleted, but it looks like we do not remove them. I did not include it in this PR, but here's the unit test:

```php
	public function test_deleted_user_should_delete_queued_items() {
		$u = $this->factory->user->create();

		$g = self::factory()->group->create();

		// Create some activity items.
		$activity_ids = self::factory()->activity->create_many(
			2,
			array(
				'user_id'   => get_current_user_id(),
				'component' => 'groups',
				'type'      => 'activity_update',
				'item_id'   => $g,
			)
		);

		// Add activity items to digest for our user.
		foreach( $activity_ids as $activity_id ) {
			ass_queue_activity_item( $activity_id, $u, $g, 'sum' );
		}

		// Now, delete user.
		wp_delete_user( $u );

		// Queued items should no longer exist.
		$query = new BPGES_Queued_Item_Query( array(
			'user_id' => $u
		) );
		$this->assertEmpty( $query->get_results() );
	}
```

And here's the fix:

```php
/**
 * Remove queued items for deleted user.
 */
add_action( 'delete_user', function( $user_id ) {
	$query = new BPGES_Queued_Item_Query( array(
		'user_id' => $user_id
	) );

	$activity_ids_to_delete = array_map( function( $item ) {
		return $item->activity_id;
	}, $query->get_results() );

	if ( ! empty( $activity_ids_to_delete ) ) {
		BPGES_Queued_Item::bulk_delete( $activity_ids_to_delete );
	}
} );
```

Could change the deletion to batches of 500 if we are concerned that a deleted user might have a ton of queued items.