### PR TITLE
Additional filters

### DIFF
--- a/bp-activity-subscription-functions.php
+++ b/bp-activity-subscription-functions.php
@@ -2456,10 +2456,6 @@ function ass_weekly_digest_week() {
  * @since 3.8.0
  */
 function bpges_register_template_stack() {
-	if ( ! bp_is_group_admin_page() ) {
-		return;
-	}
-
 	bp_register_template_stack( function() {
 		return plugin_dir_path( __FILE__ ) . '/templates/';
 	}, 20 );

--- a/bp-activity-subscription-functions.php
+++ b/bp-activity-subscription-functions.php
@@ -621,6 +621,9 @@ function bpges_generate_notification( BPGES_Queued_Item $queued_item ) {
 		$link = $activity->primary_link;
 	}
 
+	// Filter link
+	$link = apply_filters( 'bpges_notification_link', $link, $activity );
+
 	// If message has no content (as in the case of group joins, etc), we'll use a different
 	// $message template
 	if ( empty( $the_content ) ) {

--- a/bp-activity-subscription-functions.php
+++ b/bp-activity-subscription-functions.php
@@ -813,6 +813,22 @@ If you feel this service is being misused please speak to the website administra
  *                       on the email delivery class you are using.
  */
 function ass_send_email( $email_type, $to, $args ) {
+
+	// Allow overriding of email 'from'
+	$from_name  = apply_filters( 'bpges_email_from_name', null );
+	$from_email = apply_filters( 'bpges_email_from_email', null );
+	if ( ! empty( $from_name ) || ! empty( $from_email ) ) :
+		if ( ! isset( $args[ 'from' ] ) ) :
+			$args[ 'from' ] = [];
+		endif;
+		if ( ! empty( $from_name ) ) :
+			$args[ 'from' ][ 'name' ]  = $from_name;
+		endif;
+		if ( ! empty( $from_email ) ) :
+			$args[ 'from' ][ 'email' ] = $from_email;
+		endif;
+	endif;
+
 	// BP 2.5+
 	if ( true === function_exists( 'bp_send_email' ) && true === ! apply_filters( 'bp_email_use_wp_mail', false ) ) {
 		// Unset array keys used for older BP installs.

--- a/screen-admin.php
+++ b/screen-admin.php
@@ -11,20 +11,57 @@ function ass_default_subscription_settings_form() {
 	<h4><?php _e('Email Subscription Defaults', 'buddypress-group-email-subscription'); ?></h4>
 	<p><?php _e('When new users join this group, their default email notification settings will be:', 'buddypress-group-email-subscription'); ?></p>
 	<div class="radio ass-email-subscriptions-options">
-		<label id="ass-email-type_no"><input type="radio" name="ass-default-subscription" value="no" <?php ass_default_subscription_settings( 'no' ) ?> />
-			<?php _e( 'No Email (users will read this group on the web - good for any group)', 'buddypress-group-email-subscription' ) ?></label>
-		<label id="ass-email-type_sum"><input type="radio" name="ass-default-subscription" value="sum" <?php ass_default_subscription_settings( 'sum' ) ?> />
-			<?php _e( 'Weekly Summary Email (the week\'s topics - good for large groups)', 'buddypress-group-email-subscription' ) ?></label>
-		<label id="ass-email-type_dig"><input type="radio" name="ass-default-subscription" value="dig" <?php ass_default_subscription_settings( 'dig' ) ?> />
-			<?php _e( 'Daily Digest Email (all daily activity bundles in one email - good for medium-size groups)', 'buddypress-group-email-subscription' ) ?></label>
+		<?php
 
-		<?php if ( ass_get_forum_type() ) : ?>
-			<label id="ass-email-type_sub"><input type="radio" name="ass-default-subscription" value="sub" <?php ass_default_subscription_settings( 'sub' ) ?> />
-			<?php _e( 'New Topics Email (new topics are sent as they arrive, but not replies - good for small groups)', 'buddypress-group-email-subscription' ) ?></label>
-		<?php endif; ?>
+		// Wrap labels?
+		$wrap_labels = apply_filters( 'bpges_wrap_input_labels', true );
 
-		<label id="ass-email-type_supersub"><input type="radio" name="ass-default-subscription" value="supersub" <?php ass_default_subscription_settings( 'supersub' ) ?> />
-			<?php _e( 'All Email (send emails about everything - recommended only for working groups)', 'buddypress-group-email-subscription' ) ?></label>
+		// Go through email types
+		foreach ( [ 'no', 'sum', 'dig', 'sub', 'supersub' ] as $email_type ) :
+
+			// Any general checks for outputting options
+			if (
+				$email_type !== 'sub' ||
+				ass_get_forum_type()
+			) : ?>
+
+				<?php if ( $wrap_labels ) : ?>
+					<label id="ass-email-type_<?php echo $email_type; ?>">
+				<?php endif; ?>
+
+				<input type="radio" name="ass-default-subscription" value="<?php echo $email_type; ?>" <?php ass_default_subscription_settings( $email_type ); ?>>
+
+				<?php if ( ! $wrap_labels ) : ?>
+					<label id="ass-email-type_<?php echo $email_type; ?>">
+				<?php endif; ?>
+
+				<?php
+				switch ( $email_type ) :
+					case 'no':
+						_e( 'No Email (users will read this group on the web - good for any group)', 'buddypress-group-email-subscription' );
+						break;
+					case 'sum':
+						_e( 'Weekly Summary Email (the week\'s topics - good for large groups)', 'buddypress-group-email-subscription' );
+						break;
+					case 'dig':
+						_e( 'Daily Digest Email (all daily activity bundles in one email - good for medium-size groups)', 'buddypress-group-email-subscription' );
+						break;
+					case 'sub':
+						_e( 'New Topics Email (new topics are sent as they arrive, but not replies - good for small groups)', 'buddypress-group-email-subscription' );
+						break;
+					case 'supersub':
+						_e( 'All Email (send emails about everything - recommended only for working groups)', 'buddypress-group-email-subscription' );
+						break;
+				endswitch;
+				?>
+
+				</label>
+
+			<?php endif;
+
+		endforeach;
+
+		?>
 	</div>
 	<hr />
 	<?php

--- a/screen-admin.php
+++ b/screen-admin.php
@@ -29,10 +29,10 @@ function ass_default_subscription_settings_form() {
 					<label id="ass-email-type_<?php echo $email_type; ?>">
 				<?php endif; ?>
 
-				<input type="radio" name="ass-default-subscription" value="<?php echo $email_type; ?>" <?php ass_default_subscription_settings( $email_type ); ?>>
+				<input type="radio" name="ass-default-subscription" id="ass-default-subscription_<?php echo $email_type; ?>" value="<?php echo $email_type; ?>" <?php ass_default_subscription_settings( $email_type ); ?>>
 
 				<?php if ( ! $wrap_labels ) : ?>
-					<label id="ass-email-type_<?php echo $email_type; ?>">
+					<label id="ass-email-type_<?php echo $email_type; ?>" for="ass-default-subscription_<?php echo $email_type; ?>">
 				<?php endif; ?>
 
 				<?php

--- a/screen-admin.php
+++ b/screen-admin.php
@@ -11,46 +11,7 @@ function ass_default_subscription_settings_form() {
 	<h4><?php _e('Email Subscription Defaults', 'buddypress-group-email-subscription'); ?></h4>
 	<p><?php _e('When new users join this group, their default email notification settings will be:', 'buddypress-group-email-subscription'); ?></p>
 	<div class="radio ass-email-subscriptions-options">
-		<?php
-
-		// Go through email types
-		foreach ( [ 'no', 'sum', 'dig', 'sub', 'supersub' ] as $email_type ) :
-
-			// Any general checks for outputting options
-			if (
-				$email_type !== 'sub' ||
-				ass_get_forum_type()
-			) : ?>
-
-				<input type="radio" name="ass-default-subscription" id="ass-default-subscription_<?php echo $email_type; ?>" value="<?php echo $email_type; ?>" <?php ass_default_subscription_settings( $email_type ); ?>>
-
-				<label id="ass-email-type_<?php echo $email_type; ?>" for="ass-default-subscription_<?php echo $email_type; ?>">
-					<?php
-					switch ( $email_type ) :
-						case 'no':
-							_e( 'No Email (users will read this group on the web - good for any group)', 'buddypress-group-email-subscription' );
-							break;
-						case 'sum':
-							_e( 'Weekly Summary Email (the week\'s topics - good for large groups)', 'buddypress-group-email-subscription' );
-							break;
-						case 'dig':
-							_e( 'Daily Digest Email (all daily activity bundles in one email - good for medium-size groups)', 'buddypress-group-email-subscription' );
-							break;
-						case 'sub':
-							_e( 'New Topics Email (new topics are sent as they arrive, but not replies - good for small groups)', 'buddypress-group-email-subscription' );
-							break;
-						case 'supersub':
-							_e( 'All Email (send emails about everything - recommended only for working groups)', 'buddypress-group-email-subscription' );
-							break;
-					endswitch;
-					?>
-				</label>
-
-			<?php endif;
-
-		endforeach;
-
-		?>
+		<?php bp_get_template_part( 'bpges/subscription-options-admin' ); ?>
 	</div>
 	<hr />
 	<?php

--- a/screen-admin.php
+++ b/screen-admin.php
@@ -13,9 +13,6 @@ function ass_default_subscription_settings_form() {
 	<div class="radio ass-email-subscriptions-options">
 		<?php
 
-		// Wrap labels?
-		$wrap_labels = apply_filters( 'bpges_wrap_input_labels', true );
-
 		// Go through email types
 		foreach ( [ 'no', 'sum', 'dig', 'sub', 'supersub' ] as $email_type ) :
 
@@ -25,36 +22,28 @@ function ass_default_subscription_settings_form() {
 				ass_get_forum_type()
 			) : ?>
 
-				<?php if ( $wrap_labels ) : ?>
-					<label id="ass-email-type_<?php echo $email_type; ?>">
-				<?php endif; ?>
-
 				<input type="radio" name="ass-default-subscription" id="ass-default-subscription_<?php echo $email_type; ?>" value="<?php echo $email_type; ?>" <?php ass_default_subscription_settings( $email_type ); ?>>
 
-				<?php if ( ! $wrap_labels ) : ?>
-					<label id="ass-email-type_<?php echo $email_type; ?>" for="ass-default-subscription_<?php echo $email_type; ?>">
-				<?php endif; ?>
-
-				<?php
-				switch ( $email_type ) :
-					case 'no':
-						_e( 'No Email (users will read this group on the web - good for any group)', 'buddypress-group-email-subscription' );
-						break;
-					case 'sum':
-						_e( 'Weekly Summary Email (the week\'s topics - good for large groups)', 'buddypress-group-email-subscription' );
-						break;
-					case 'dig':
-						_e( 'Daily Digest Email (all daily activity bundles in one email - good for medium-size groups)', 'buddypress-group-email-subscription' );
-						break;
-					case 'sub':
-						_e( 'New Topics Email (new topics are sent as they arrive, but not replies - good for small groups)', 'buddypress-group-email-subscription' );
-						break;
-					case 'supersub':
-						_e( 'All Email (send emails about everything - recommended only for working groups)', 'buddypress-group-email-subscription' );
-						break;
-				endswitch;
-				?>
-
+				<label id="ass-email-type_<?php echo $email_type; ?>" for="ass-default-subscription_<?php echo $email_type; ?>">
+					<?php
+					switch ( $email_type ) :
+						case 'no':
+							_e( 'No Email (users will read this group on the web - good for any group)', 'buddypress-group-email-subscription' );
+							break;
+						case 'sum':
+							_e( 'Weekly Summary Email (the week\'s topics - good for large groups)', 'buddypress-group-email-subscription' );
+							break;
+						case 'dig':
+							_e( 'Daily Digest Email (all daily activity bundles in one email - good for medium-size groups)', 'buddypress-group-email-subscription' );
+							break;
+						case 'sub':
+							_e( 'New Topics Email (new topics are sent as they arrive, but not replies - good for small groups)', 'buddypress-group-email-subscription' );
+							break;
+						case 'supersub':
+							_e( 'All Email (send emails about everything - recommended only for working groups)', 'buddypress-group-email-subscription' );
+							break;
+					endswitch;
+					?>
 				</label>
 
 			<?php endif;

--- a/screen-notifications.php
+++ b/screen-notifications.php
@@ -18,8 +18,6 @@ function ass_group_subscribe_settings () {
 
 	$submit_link = bp_get_groups_action_link( 'notifications' );
 
-	$wrap_labels = apply_filters( 'bpges_wrap_input_labels', true );
-
 	?>
 	<div id="ass-email-subscriptions-options-page">
 	<h3 class="activity-subscription-settings-title"><?php _e('Email Subscription Options', 'buddypress-group-email-subscription') ?></h3>
@@ -30,29 +28,29 @@ function ass_group_subscribe_settings () {
 	<b><?php _e('How do you want to read this group?', 'buddypress-group-email-subscription'); ?></b>
 
 	<div class="ass-email-type" id="ass-email-type_no">
-		<?php if ( $wrap_labels ) : ?><label><?php endif; ?><input type="radio" name="ass_group_subscribe" id="ass_group_subscribe_no" value="no" <?php if ( $group_status == "no" || $group_status == "un" || !$group_status ) echo 'checked="checked"'; ?>><?php if ( ! $wrap_labels ) : ?><label for="ass_group_subscribe_no"><?php endif; ?><?php _e('No Email', 'buddypress-group-email-subscription'); ?></label>
+		<input type="radio" name="ass_group_subscribe" id="ass_group_subscribe_no" value="no" <?php if ( $group_status == "no" || $group_status == "un" || !$group_status ) echo 'checked="checked"'; ?>><label for="ass_group_subscribe_no"><?php _e('No Email', 'buddypress-group-email-subscription'); ?></label>
 		<div class="ass-email-explain"><?php _e('I will read this group on the web', 'buddypress-group-email-subscription'); ?></div>
 	</div>
 
 	<div class="ass-email-type" id="ass-email-type_sum">
-		<?php if ( $wrap_labels ) : ?><label><?php endif; ?><input type="radio" name="ass_group_subscribe" id="ass_group_subscribe_sum" value="sum" <?php if ( $group_status == "sum" ) echo 'checked="checked"'; ?>><?php if ( ! $wrap_labels ) : ?><label for="ass_group_subscribe_sum"><?php endif; ?><?php _e('Weekly Summary Email', 'buddypress-group-email-subscription'); ?></label>
+		<input type="radio" name="ass_group_subscribe" id="ass_group_subscribe_sum" value="sum" <?php if ( $group_status == "sum" ) echo 'checked="checked"'; ?>><label for="ass_group_subscribe_sum"><?php _e('Weekly Summary Email', 'buddypress-group-email-subscription'); ?></label>
 		<div class="ass-email-explain"><?php _e('Get a summary of new topics each week', 'buddypress-group-email-subscription'); ?></div>
 	</div>
 
 	<div class="ass-email-type" id="ass-email-type_dig">
-		<?php if ( $wrap_labels ) : ?><label><?php endif; ?><input type="radio" name="ass_group_subscribe" id="ass_group_subscribe_dig" value="dig" <?php if ( $group_status == "dig" ) echo 'checked="checked"'; ?>><?php if ( ! $wrap_labels ) : ?><label for="ass_group_subscribe_dig"><?php endif; ?><?php _e('Daily Digest Email', 'buddypress-group-email-subscription'); ?></label>
+		<input type="radio" name="ass_group_subscribe" id="ass_group_subscribe_dig" value="dig" <?php if ( $group_status == "dig" ) echo 'checked="checked"'; ?>><label for="ass_group_subscribe_dig"><?php _e('Daily Digest Email', 'buddypress-group-email-subscription'); ?></label>
 		<div class="ass-email-explain"><?php _e('Get all the day\'s activity bundled into a single email', 'buddypress-group-email-subscription'); ?></div>
 	</div>
 
 	<?php if ( ass_get_forum_type() ) : ?>
 		<div class="ass-email-type" id="ass-email-type_sub">
-			<?php if ( $wrap_labels ) : ?><label><?php endif; ?><input type="radio" name="ass_group_subscribe" value="sub" id="ass_group_subscribe_sub" <?php if ( $group_status == "sub" ) echo 'checked="checked"'; ?>><?php if ( ! $wrap_labels ) : ?><label for="ass_group_subscribe_sub"><?php endif; ?><?php _e('New Topics Email', 'buddypress-group-email-subscription'); ?></label>
+			<input type="radio" name="ass_group_subscribe" value="sub" id="ass_group_subscribe_sub" <?php if ( $group_status == "sub" ) echo 'checked="checked"'; ?>><label for="ass_group_subscribe_sub"><?php _e('New Topics Email', 'buddypress-group-email-subscription'); ?></label>
 			<div class="ass-email-explain"><?php _e('Send new topics as they arrive (but don\'t send replies)', 'buddypress-group-email-subscription'); ?></div>
 		</div>
 	<?php endif; ?>
 
 	<div class="ass-email-type" id="ass-email-type_supersub">
-		<?php if ( $wrap_labels ) : ?><label><?php endif; ?><input type="radio" name="ass_group_subscribe" value="supersub" id="ass_group_subscribe_supersub" <?php if ( $group_status == "supersub" ) echo 'checked="checked"'; ?>><?php if ( ! $wrap_labels ) : ?><label for="ass_group_subscribe_supersub"><?php endif; ?><?php _e('All Email', 'buddypress-group-email-subscription'); ?></label>
+		<input type="radio" name="ass_group_subscribe" value="supersub" id="ass_group_subscribe_supersub" <?php if ( $group_status == "supersub" ) echo 'checked="checked"'; ?>><label for="ass_group_subscribe_supersub"><?php _e('All Email', 'buddypress-group-email-subscription'); ?></label>
 		<div class="ass-email-explain"><?php _e('Send all group activity as it arrives', 'buddypress-group-email-subscription'); ?></div>
 	</div>
 

--- a/screen-notifications.php
+++ b/screen-notifications.php
@@ -18,6 +18,8 @@ function ass_group_subscribe_settings () {
 
 	$submit_link = bp_get_groups_action_link( 'notifications' );
 
+	$wrap_labels = apply_filters( 'bpges_wrap_input_labels', true );
+
 	?>
 	<div id="ass-email-subscriptions-options-page">
 	<h3 class="activity-subscription-settings-title"><?php _e('Email Subscription Options', 'buddypress-group-email-subscription') ?></h3>
@@ -28,30 +30,30 @@ function ass_group_subscribe_settings () {
 	<b><?php _e('How do you want to read this group?', 'buddypress-group-email-subscription'); ?></b>
 
 	<div class="ass-email-type" id="ass-email-type_no">
-	<label><input type="radio" name="ass_group_subscribe" value="no" <?php if ( $group_status == "no" || $group_status == "un" || !$group_status ) echo 'checked="checked"'; ?>><?php _e('No Email', 'buddypress-group-email-subscription'); ?></label>
-	<div class="ass-email-explain"><?php _e('I will read this group on the web', 'buddypress-group-email-subscription'); ?></div>
+		<?php if ( $wrap_labels ) : ?><label><?php endif; ?><input type="radio" name="ass_group_subscribe" id="ass_group_subscribe_no" value="no" <?php if ( $group_status == "no" || $group_status == "un" || !$group_status ) echo 'checked="checked"'; ?>><?php if ( ! $wrap_labels ) : ?><label for="ass_group_subscribe_no"><?php endif; ?><?php _e('No Email', 'buddypress-group-email-subscription'); ?></label>
+		<div class="ass-email-explain"><?php _e('I will read this group on the web', 'buddypress-group-email-subscription'); ?></div>
 	</div>
 
 	<div class="ass-email-type" id="ass-email-type_sum">
-	<label><input type="radio" name="ass_group_subscribe" value="sum" <?php if ( $group_status == "sum" ) echo 'checked="checked"'; ?>><?php _e('Weekly Summary Email', 'buddypress-group-email-subscription'); ?></label>
-	<div class="ass-email-explain"><?php _e('Get a summary of new topics each week', 'buddypress-group-email-subscription'); ?></div>
+		<?php if ( $wrap_labels ) : ?><label><?php endif; ?><input type="radio" name="ass_group_subscribe" id="ass_group_subscribe_sum" value="sum" <?php if ( $group_status == "sum" ) echo 'checked="checked"'; ?>><?php if ( ! $wrap_labels ) : ?><label for="ass_group_subscribe_sum"><?php endif; ?><?php _e('Weekly Summary Email', 'buddypress-group-email-subscription'); ?></label>
+		<div class="ass-email-explain"><?php _e('Get a summary of new topics each week', 'buddypress-group-email-subscription'); ?></div>
 	</div>
 
 	<div class="ass-email-type" id="ass-email-type_dig">
-	<label><input type="radio" name="ass_group_subscribe" value="dig" <?php if ( $group_status == "dig" ) echo 'checked="checked"'; ?>><?php _e('Daily Digest Email', 'buddypress-group-email-subscription'); ?></label>
-	<div class="ass-email-explain"><?php _e('Get all the day\'s activity bundled into a single email', 'buddypress-group-email-subscription'); ?></div>
+		<?php if ( $wrap_labels ) : ?><label><?php endif; ?><input type="radio" name="ass_group_subscribe" id="ass_group_subscribe_dig" value="dig" <?php if ( $group_status == "dig" ) echo 'checked="checked"'; ?>><?php if ( ! $wrap_labels ) : ?><label for="ass_group_subscribe_dig"><?php endif; ?><?php _e('Daily Digest Email', 'buddypress-group-email-subscription'); ?></label>
+		<div class="ass-email-explain"><?php _e('Get all the day\'s activity bundled into a single email', 'buddypress-group-email-subscription'); ?></div>
 	</div>
 
 	<?php if ( ass_get_forum_type() ) : ?>
 		<div class="ass-email-type" id="ass-email-type_sub">
-		<label><input type="radio" name="ass_group_subscribe" value="sub" <?php if ( $group_status == "sub" ) echo 'checked="checked"'; ?>><?php _e('New Topics Email', 'buddypress-group-email-subscription'); ?></label>
-		<div class="ass-email-explain"><?php _e('Send new topics as they arrive (but don\'t send replies)', 'buddypress-group-email-subscription'); ?></div>
+			<?php if ( $wrap_labels ) : ?><label><?php endif; ?><input type="radio" name="ass_group_subscribe" value="sub" id="ass_group_subscribe_sub" <?php if ( $group_status == "sub" ) echo 'checked="checked"'; ?>><?php if ( ! $wrap_labels ) : ?><label for="ass_group_subscribe_sub"><?php endif; ?><?php _e('New Topics Email', 'buddypress-group-email-subscription'); ?></label>
+			<div class="ass-email-explain"><?php _e('Send new topics as they arrive (but don\'t send replies)', 'buddypress-group-email-subscription'); ?></div>
 		</div>
 	<?php endif; ?>
 
 	<div class="ass-email-type" id="ass-email-type_supersub">
-	<label><input type="radio" name="ass_group_subscribe" value="supersub" <?php if ( $group_status == "supersub" ) echo 'checked="checked"'; ?>><?php _e('All Email', 'buddypress-group-email-subscription'); ?></label>
-	<div class="ass-email-explain"><?php _e('Send all group activity as it arrives', 'buddypress-group-email-subscription'); ?></div>
+		<?php if ( $wrap_labels ) : ?><label><?php endif; ?><input type="radio" name="ass_group_subscribe" value="supersub" id="ass_group_subscribe_supersub" <?php if ( $group_status == "supersub" ) echo 'checked="checked"'; ?>><?php if ( ! $wrap_labels ) : ?><label for="ass_group_subscribe_supersub"><?php endif; ?><?php _e('All Email', 'buddypress-group-email-subscription'); ?></label>
+		<div class="ass-email-explain"><?php _e('Send all group activity as it arrives', 'buddypress-group-email-subscription'); ?></div>
 	</div>
 
 	<input type="submit" value="<?php _e('Save Settings', 'buddypress-group-email-subscription') ?>" id="ass-save" name="ass-save" class="button-primary">

--- a/screen-notifications.php
+++ b/screen-notifications.php
@@ -14,8 +14,6 @@ function ass_group_subscribe_settings () {
 	if ( !is_user_logged_in() || !empty( $group->is_banned ) || !$group->is_member )
 		return false;
 
-	$group_status = ass_get_group_subscription_status( bp_loggedin_user_id(), $group->id );
-
 	$submit_link = bp_get_groups_action_link( 'notifications' );
 
 	?>
@@ -27,32 +25,7 @@ function ass_group_subscribe_settings () {
 
 	<b><?php _e('How do you want to read this group?', 'buddypress-group-email-subscription'); ?></b>
 
-	<div class="ass-email-type" id="ass-email-type_no">
-		<input type="radio" name="ass_group_subscribe" id="ass_group_subscribe_no" value="no" <?php if ( $group_status == "no" || $group_status == "un" || !$group_status ) echo 'checked="checked"'; ?>><label for="ass_group_subscribe_no"><?php _e('No Email', 'buddypress-group-email-subscription'); ?></label>
-		<div class="ass-email-explain"><?php _e('I will read this group on the web', 'buddypress-group-email-subscription'); ?></div>
-	</div>
-
-	<div class="ass-email-type" id="ass-email-type_sum">
-		<input type="radio" name="ass_group_subscribe" id="ass_group_subscribe_sum" value="sum" <?php if ( $group_status == "sum" ) echo 'checked="checked"'; ?>><label for="ass_group_subscribe_sum"><?php _e('Weekly Summary Email', 'buddypress-group-email-subscription'); ?></label>
-		<div class="ass-email-explain"><?php _e('Get a summary of new topics each week', 'buddypress-group-email-subscription'); ?></div>
-	</div>
-
-	<div class="ass-email-type" id="ass-email-type_dig">
-		<input type="radio" name="ass_group_subscribe" id="ass_group_subscribe_dig" value="dig" <?php if ( $group_status == "dig" ) echo 'checked="checked"'; ?>><label for="ass_group_subscribe_dig"><?php _e('Daily Digest Email', 'buddypress-group-email-subscription'); ?></label>
-		<div class="ass-email-explain"><?php _e('Get all the day\'s activity bundled into a single email', 'buddypress-group-email-subscription'); ?></div>
-	</div>
-
-	<?php if ( ass_get_forum_type() ) : ?>
-		<div class="ass-email-type" id="ass-email-type_sub">
-			<input type="radio" name="ass_group_subscribe" value="sub" id="ass_group_subscribe_sub" <?php if ( $group_status == "sub" ) echo 'checked="checked"'; ?>><label for="ass_group_subscribe_sub"><?php _e('New Topics Email', 'buddypress-group-email-subscription'); ?></label>
-			<div class="ass-email-explain"><?php _e('Send new topics as they arrive (but don\'t send replies)', 'buddypress-group-email-subscription'); ?></div>
-		</div>
-	<?php endif; ?>
-
-	<div class="ass-email-type" id="ass-email-type_supersub">
-		<input type="radio" name="ass_group_subscribe" value="supersub" id="ass_group_subscribe_supersub" <?php if ( $group_status == "supersub" ) echo 'checked="checked"'; ?>><label for="ass_group_subscribe_supersub"><?php _e('All Email', 'buddypress-group-email-subscription'); ?></label>
-		<div class="ass-email-explain"><?php _e('Send all group activity as it arrives', 'buddypress-group-email-subscription'); ?></div>
-	</div>
+	<?php bp_get_template_part( 'bpges/subscription-options-group' ); ?>
 
 	<input type="submit" value="<?php _e('Save Settings', 'buddypress-group-email-subscription') ?>" id="ass-save" name="ass-save" class="button-primary">
 

--- a/templates/bpges/subscription-options-admin.php
+++ b/templates/bpges/subscription-options-admin.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Subscription options template for group admin screen (Group > Manage > Settings)
+ */
+
+?>
+
+<label id="ass-email-type_no" for="ass-default-subscription_no">
+	<input type="radio" name="ass-default-subscription" id="ass-default-subscription_no" value="no" <?php ass_default_subscription_settings( 'no' ); ?> />
+	<?php _e( 'No Email (users will read this group on the web - good for any group)', 'buddypress-group-email-subscription' ); ?>
+</label>
+<label id="ass-email-type_sum" for="ass-default-subscription_sum">
+	<input type="radio" name="ass-default-subscription" id="ass-default-subscription_sum" value="sum" <?php ass_default_subscription_settings( 'sum' ); ?> />
+	<?php _e( 'Weekly Summary Email (the week\'s topics - good for large groups)', 'buddypress-group-email-subscription' ); ?>
+</label>
+<label id="ass-email-type_dig" for="ass-default-subscription_dig">
+	<input type="radio" name="ass-default-subscription" id="ass-default-subscription_dig" value="dig" <?php ass_default_subscription_settings( 'dig' ); ?> />
+	<?php _e( 'Daily Digest Email (all daily activity bundles in one email - good for medium-size groups)', 'buddypress-group-email-subscription' ); ?>
+</label>
+
+<?php if ( ass_get_forum_type() ) : ?>
+	<label id="ass-email-type_sub" for="ass-default-subscription_sub">
+		<input type="radio" name="ass-default-subscription" id="ass-default-subscription_sub" value="sub" <?php ass_default_subscription_settings( 'sub' ); ?> />
+		<?php _e( 'New Topics Email (new topics are sent as they arrive, but not replies - good for small groups)', 'buddypress-group-email-subscription' ); ?>
+	</label>
+<?php endif; ?>
+
+<label id="ass-email-type_supersub" for="ass-default-subscription_supersub">
+	<input type="radio" name="ass-default-subscription" id="ass-default-subscription_supersub" value="supersub" <?php ass_default_subscription_settings( 'supersub' ); ?> />
+	<?php _e( 'All Email (send emails about everything - recommended only for working groups)', 'buddypress-group-email-subscription' ); ?>
+</label>

--- a/templates/bpges/subscription-options-group.php
+++ b/templates/bpges/subscription-options-group.php
@@ -11,7 +11,7 @@ $group_status = ass_get_group_subscription_status( bp_loggedin_user_id(), $group
 ?>
 
 <div class="ass-email-type" id="ass-email-type_no">
-	<label for="ass_group_subscribe_no"><input type="radio" name="ass_group_subscribe" id="ass_group_subscribe_no" value="no" <?php if ( $group_status == "no" || $group_status == "un" || ! $group_status ) { echo 'checked="checked"'; } ?>><?php _e( 'No Email????', 'buddypress-group-email-subscription' ); ?></label>
+	<label for="ass_group_subscribe_no"><input type="radio" name="ass_group_subscribe" id="ass_group_subscribe_no" value="no" <?php if ( $group_status == "no" || $group_status == "un" || ! $group_status ) { echo 'checked="checked"'; } ?>><?php _e( 'No Email', 'buddypress-group-email-subscription' ); ?></label>
 	<div class="ass-email-explain"><?php _e( 'I will read this group on the web', 'buddypress-group-email-subscription' ); ?></div>
 </div>
 

--- a/templates/bpges/subscription-options-group.php
+++ b/templates/bpges/subscription-options-group.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Subscription options template for group member options screen (Group > Email Options)
+ */
+
+// Init
+$group        = groups_get_current_group();
+$group_status = ass_get_group_subscription_status( bp_loggedin_user_id(), $group->id );
+
+?>
+
+<div class="ass-email-type" id="ass-email-type_no">
+	<label for="ass_group_subscribe_no"><input type="radio" name="ass_group_subscribe" id="ass_group_subscribe_no" value="no" <?php if ( $group_status == "no" || $group_status == "un" || ! $group_status ) { echo 'checked="checked"'; } ?>><?php _e( 'No Email????', 'buddypress-group-email-subscription' ); ?></label>
+	<div class="ass-email-explain"><?php _e( 'I will read this group on the web', 'buddypress-group-email-subscription' ); ?></div>
+</div>
+
+<div class="ass-email-type" id="ass-email-type_sum">
+	<label for="ass_group_subscribe_sum"><input type="radio" name="ass_group_subscribe" id="ass_group_subscribe_sum" value="sum" <?php if ( $group_status == "sum" ) { echo 'checked="checked"'; } ?>><?php _e( 'Weekly Summary Email', 'buddypress-group-email-subscription' ); ?></label>
+	<div class="ass-email-explain"><?php _e( 'Get a summary of new topics each week', 'buddypress-group-email-subscription' ); ?></div>
+</div>
+
+<div class="ass-email-type" id="ass-email-type_dig">
+	<label for="ass_group_subscribe_dig"><input type="radio" name="ass_group_subscribe" id="ass_group_subscribe_dig" value="dig" <?php if ( $group_status == "dig" ) { echo 'checked="checked"'; } ?>><?php _e( 'Daily Digest Email', 'buddypress-group-email-subscription' ); ?></label>
+	<div class="ass-email-explain"><?php _e( 'Get all the day\'s activity bundled into a single email', 'buddypress-group-email-subscription' ); ?></div>
+</div>
+
+<?php if ( ass_get_forum_type() ) : ?>
+	<div class="ass-email-type" id="ass-email-type_sub">
+		<label for="ass_group_subscribe_sub"><input type="radio" name="ass_group_subscribe" id="ass_group_subscribe_sub" value="sub" <?php if ( $group_status == "sub" ) { echo 'checked="checked"'; } ?>><?php _e( 'New Topics Email', 'buddypress-group-email-subscription' ); ?></label>
+		<div class="ass-email-explain"><?php _e( 'Send new topics as they arrive (but don\'t send replies)', 'buddypress-group-email-subscription' ); ?></div>
+	</div>
+<?php endif; ?>
+
+<div class="ass-email-type" id="ass-email-type_supersub">
+	<label for="ass_group_subscribe_supersub"><input type="radio" name="ass_group_subscribe" id="ass_group_subscribe_supersub" value="supersub" <?php if ( $group_status == "supersub" ) { echo 'checked="checked"'; } ?>><?php _e( 'All Email', 'buddypress-group-email-subscription' ); ?></label>
+	<div class="ass-email-explain"><?php _e( 'Send all group activity as it arrives', 'buddypress-group-email-subscription' ); ?></div>
+</div>


### PR DESCRIPTION
As discussed here: https://wordpress.org/support/topic/large-number-of-notifications-holding-up-ajax-response/ And here: https://wordpress.org/support/topic/working-on-changes-to-ass_group_notification_activity-function/

- I've altered the subscription options markup, and included the `bpges_wrap_input_labels` filter to control this markup (defaults to true).
- I've added the `bpges_email_from_name` and `bpges_email_from_email` filters to control the email from name / address.
- I've added the `bpges_notification_link` filter to control the link included in notifications.

Let me know if you've any questions.