### PR TITLE
Set $post_exists_check flag to true by default in ass_install_emails()

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -381,9 +381,9 @@ add_action( 'bp_groups_admin_manage_member_row', 'ass_groups_admin_manage_member
  * @since 3.7.0
  *
  * @param bool $post_exists_check Should we check to see if our email post types exist before installing?
- *                                Default: false.
+ *                                Default: true.
  */
-function ass_install_emails( $post_exists_check = false ) {
+function ass_install_emails( $post_exists_check = true ) {
 	if ( ! function_exists( 'ass_set_email_type' ) ) {
 		require_once( __DIR__ . '/bp-activity-subscription-functions.php' );
 	}


### PR DESCRIPTION
Currently, `ass_install_emails()` is hooked to the `'bp_core_install_emails'` hook:
https://github.com/boonebgorges/buddypress-group-email-subscription/blob/d322c0bfb053b9ee23d1e25a250717d1e506313a/admin.php#L378-L445

So whenever BuddyPress (or another plugin)
calls on the `bp_core_install_emails()` function, BPGES will always install their email templates without checking if they exist first.

Since BuddyPress has internally called on `bp_core_install_emails()` in their update routine in the past few releases, duplicate GES email templates were unintentionally being created:
* https://github.com/buddypress/buddypress/blob/c9b0e32face9b2e028184d7dad0ffd14fee87919/src/bp-core/bp-core-update.php#L636
* https://github.com/buddypress/buddypress/blob/c9b0e32face9b2e028184d7dad0ffd14fee87919/src/bp-core/bp-core-update.php#L725

Setting the `$post_exists_check` default flag to `true` will fix this problem.