### PR TITLE
Only install our email templates if they do not exist

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -442,7 +442,14 @@ function ass_install_emails( $post_exists_check = true ) {
 		}
 	}
 }
-add_action( 'bp_core_install_emails', 'ass_install_emails' );
+
+// Install our emails if necessary.
+add_action(
+	'bp_core_install_emails',
+	function() {
+		ass_install_emails();
+	}
+);
 
 /**
  * Show admin notice when editing a BP email in the admin dashboard.


### PR DESCRIPTION
This PR is the proper fix for #221.

All I can say is: Groan. I'm pretty sure I tested the previous fix and it was working. However, the default function parameter for `ass_install_emails()` no longer works properly when passed to an empty `do_action()` parameter call like the `'bp_core_install_emails'` hook. What seems to work is an anonymous function call on the `'bp_core_install_emails'` hook, so that's what I'm rolling with!