### PR TITLE
Users subscribed to 'No Email' should not receive email

### DIFF
--- a/bp-activity-subscription-functions.php
+++ b/bp-activity-subscription-functions.php
@@ -164,6 +164,11 @@ function ass_group_notification_activity( BP_Activity_Activity $activity ) {
 	foreach ( $subscribed_users as $user_id => $subscription_type ) {
 		$self_notify = false;
 
+		// Email is set to 'No Email', so bail.
+		if ( 'no' === $subscription_type ) {
+			continue;
+		}
+
 		// Does the author want updates of their own forum posts?
 		if ( 'bbp_topic_create' === $activity->type || 'bbp_reply_create' === $activity->type ) {
 			if ( $user_id === $activity->user_id ) {


### PR DESCRIPTION
See #239.

This issue appears to have occurred once we migrated user email subscription settings to our custom DB table and when we moved to async sending. When a user's email setting is set to `'no'`, we do not delete the entry in the DB table, but keep the option in the DB saved as `'no'`, so we need to account for that during email sending.

I've added a fix for this, but I'm unsure if this is the right place to bail from the email sending. In the PR, I put the bail at the front of the loop, but that bypasses a bunch of filters:

https://github.com/boonebgorges/buddypress-group-email-subscription/blob/99bf83a27802b33fbd246c9998b2f2305da06f19/bp-activity-subscription-functions.php#L221-L238

It might make sense to put the fix before or after the block I mentioned above.