### PR TITLE
Fix self notify lookup during email sending

### DIFF
--- a/bp-activity-subscription-functions.php
+++ b/bp-activity-subscription-functions.php
@@ -787,13 +787,14 @@ To view or reply, log in and go to:
 		$the_content = apply_filters( 'bp_ass_activity_notification_content', $the_content, $activity, $action_for_email_content, $group );
 
 		// Check for $self_notify status.
-		$self_notify = ass_self_post_notification( $user_id );
-		if ( ! empty( $self_notify ) && (int) $activity->user_id === (int) $user_id ) {
-			$group_status = 'self_notify';
+		if ( (int) $activity->user_id === (int) $user_id ) {
+			$self_notify = ass_self_post_notification( $user_id );
 		}
 	}
 
 	if ( $self_notify ) {
+		$group_status = 'self_notify';
+
 		// notification settings link
 		$settings_link = bp_members_get_user_url(
 			$user_id,


### PR DESCRIPTION
Encountered an issue in the email content where the `{{ges.email-setting-description}}` and `{{ges.email-setting-links}}` tokens would always show the self-notify setting instead of the user's group email setting.

The issue stems from always looking up the user's self notify option instead of only doing it once the activity user ID matches the email recipient's user ID during email sending in `bpges_generate_notification()`.